### PR TITLE
CMake: Changed to use CMake instead of make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,65 @@
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio
+
+*.iml
+
+## Directory-based project format:
+.idea/
+# if you remove the above rule, at least ignore the following:
+
+# User-specific stuff:
+# .idea/workspace.xml
+# .idea/tasks.xml
+# .idea/dictionaries
+
+# Sensitive or high-churn files:
+# .idea/dataSources.ids
+# .idea/dataSources.xml
+# .idea/sqlDataSources.xml
+# .idea/dynamic.xml
+# .idea/uiDesigner.xml
+
+# Gradle:
+# .idea/gradle.xml
+# .idea/libraries
+
+# Mongo Explorer plugin:
+# .idea/mongoSettings.xml
+
+## File-based project format:
+*.ipr
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+
+# CMake generated files
+/CMakeFiles/
+/Makefile
+/CMakeCache.txt
+/cmake_install.cmake
+
+# Lex and Yacc files
+/src/lex.yy.c
+/src/lex.yy.cc
+/src/y.output
+/src/y.tab.c
+/src/y.tab.h
+/src/y.tab.cc
+/src/y.tab.hh
+
+/bin
+/obj
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 3.2)
+project(apus)
+
+# Append compile option
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+set(SRC src)
+set(INCLUDE include)
+
+set(LEX lex)
+set(YACC yacc)
+
+# Add include directory
+include_directories("${INCLUDE}")
+
+# Scan whole files under 'src' and 'include' folders, recursively.
+file(GLOB_RECURSE SOURCE_FILES "${SRC}/*.cpp" "${SRC}/*.cc" "${SRC}/*.c")
+file(GLOB_RECURSE HEADER_FILES "${INCLUDE}/*.hpp" "${INCLUDE}/*.hh" "${INCLUDE}/*.h")
+
+# Build executable
+add_executable(apus ${SOURCE_FILES} ${HEADER_FILES})
+
+# lex
+add_custom_target(
+    lex ${LEX} -o lex.yy.cc ${CMAKE_SOURCE_DIR}/${SRC}/apus.l
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/${SRC}
+    COMMENT "exec lex"
+)
+
+# yacc
+add_custom_target(
+    yacc ${YACC} -dv -o y.tab.cc ${CMAKE_SOURCE_DIR}/${SRC}/apus.y
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/${SRC}
+    COMMENT "exex yacc"
+)
+
+add_dependencies(apus lex;yacc)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,0 @@
-all:
-	make -C src 
-
-clean:
-	make clean -C src

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # apus
+
+
+## Build
+
+### Linux or Mac OS X
+
+```
+$ cmake ./    
+$ make
+```

--- a/src/apus.l
+++ b/src/apus.l
@@ -1,12 +1,10 @@
 %{
 #include <stdio.h>
-#include "y.tab.h"
+#include "y.tab.hh"
 
-int yywrap(void) {
-    return 1;
-}
 %}
 
+%option noyywrap
 %option yylineno
 
 %%
@@ -90,7 +88,7 @@ int yywrap(void) {
     return DOUBLE_LITERAL;
 }
 [a-z]+[0-9a-z_]* {
-    yylval.str_val = malloc(yyleng);
+    yylval.str_val = (char*)malloc(yyleng);
     sprintf(yylval.str_val, "%s", yytext);
     // Sting control : yytext[NUM] 
     return ID;

--- a/src/apus.y
+++ b/src/apus.y
@@ -1,6 +1,10 @@
 %{
 #include <stdio.h>
 #include <stdlib.h>
+
+extern int yylex(void);
+extern int yyparse(void);
+extern int yyerror(char const *str);
 %}
 %union {
     int64_t int_val;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,3 @@
+int main(int argc, char** argv) {
+    return 0;
+}


### PR DESCRIPTION
1. Added 'CMakeLists.txt'.  To build, run 'cmake ./' and 'make'
2. Removed 'Makefile'
3. Added CMake instructions on README.md
4. Added simple 'main()' on main.cpp
5. Added .gitignore to exclude auto generated stuffs
6. In apus.l, include "y.tab.hh" instead of "y.tab.h" (output file changed). And, error making missed casting inserted.
7. Added in apus.y external declarations of yylex, yyparse, yyerror.
