### PR TITLE
parser: Added expression

### DIFF
--- a/src/apus.l
+++ b/src/apus.l
@@ -84,7 +84,6 @@ int yywrap(void) {
 "("  { return OPEN; }
 ")"  { return CLOSE; }
 "\n" { return CR; }
-"\"" { return QUO; }
 
 [1-9][0-9]* {
     int temp;
@@ -104,6 +103,10 @@ int yywrap(void) {
     // Sting control : yytext[NUM] 
     return ID;
 }
+
+'([^'\n|\\'])'     { return CHAR_LITERAL; }
+\"([^"\n]|\\\")*\" { return STRING_LITERAL; }
+
 [#]+.*[\n] ;
 [\t ]+ ;
 %%

--- a/src/apus.l
+++ b/src/apus.l
@@ -57,6 +57,8 @@ int yywrap(void) {
 "|" { return OR; }
 "&" { return AND; }
 "%" { return MOD; }
+"~" { return REVERSE; }
+"^" { return XOR; }
 
 "==" { return EQL; }
 "<"  { return LSS; }

--- a/src/apus.l
+++ b/src/apus.l
@@ -41,15 +41,20 @@ int yywrap(void) {
 "true"    { return TRUE; }
 "false"   { return FALSE; }
 
-"+=" { return ADDASSIGN; }
-"-=" { return SUBASSIGN; }
-"*=" { return MULASSIGN; }
-"/=" { return DIVASSIGN; }
-"%=" { return MODASSIGN; }
-"<<" { return LSHIFT; }
-">>" { return RSHIFT; }
-"||" { return LOR; }
-"&&" { return LAND; }
+"+="  { return ADDASSIGN; }
+"-="  { return SUBASSIGN; }
+"*="  { return MULASSIGN; }
+"/="  { return DIVASSIGN; }
+"%="  { return MODASSIGN; }
+"|="  { return ORASSIGN; }
+"&="  { return ANDASSIGN; }
+"^="  { return XORASSIGN; }
+"<<=" { return LSASSIGN; }
+">>=" { return RSASSIGN; }
+"<<"  { return LSHIFT; }
+">>"  { return RSHIFT; }
+"||"  { return LOR; }
+"&&"  { return LAND; }
  
 "+" { return ADD; }
 "-" { return SUB; }

--- a/src/apus.l
+++ b/src/apus.l
@@ -48,6 +48,8 @@ int yywrap(void) {
 "%=" { return MODASSIGN; }
 "<<" { return LSHIFT; }
 ">>" { return RSHIFT; }
+"||" { return LOR; }
+"&&" { return LAND; }
  
 "+" { return ADD; }
 "-" { return SUB; }

--- a/src/apus.y
+++ b/src/apus.y
@@ -96,12 +96,14 @@ primary_expression :
     | DOUBLE_LITERAL
     ;
 union_declaration :
-    UNION ID L_BRACE local_declaration_list R_BRACE
-    | UNION ID CR L_BRACE local_declaration_list R_BRACE
+    UNION ID block_start local_declaration_list R_BRACE
     ;
 struct_declaration :
-    STRUCT ID L_BRACE local_declaration_list R_BRACE
-    | STRUCT ID CR L_BRACE local_declaration_list R_BRACE
+    STRUCT ID block_start local_declaration_list R_BRACE
+    ;
+block_start :
+    L_BRACE
+    | CR L_BRACE
     ;
 local_declaration_list :
     local_declaration

--- a/src/apus.y
+++ b/src/apus.y
@@ -24,7 +24,7 @@
 %token COMMENT CR QUO DOT VAR SEMI
 %token INCLUDE IF ELSE FOR EXIT TRUE FALSE RETURN
 
-%right ASSIGN
+%right ASSIGN ADDASSIGN SUBASSIGN MULASSIGN DIVASSIGN MODASSIGN ORASSIGN ANDASSIGN XORASSIGN LSASSIGN RSASSIGN
 %left LOR
 %left LAND
 %left OR
@@ -67,7 +67,8 @@ array :
     | L_CASE expression R_CASE ID ASSIGN expression
     ;
 expression :
-    expression LOR expression
+    expression assign_operator expression
+    | expression LOR expression
     | expression LAND expression
     | expression OR expression
     | expression XOR expression
@@ -123,6 +124,12 @@ type_specifier :
     | F32 | F64
     | C8 | C16 | C32
     | STR | STR8 | STR16 | STR32
+    ;
+assign_operator :
+    ASSIGN | ADDASSIGN | SUBASSIGN
+    | MULASSIGN | DIVASSIGN | MODASSIGN
+    | ORASSIGN | ANDASSIGN | XORASSIGN
+    | LSASSIGN | RSASSIGN
     ;
 action_declaration : 
     DOUBLE_LITERAL

--- a/src/apus.y
+++ b/src/apus.y
@@ -108,13 +108,8 @@ local_declaration_list :
     | local_declaration local_declaration_list
     ;
 local_declaration :
-    local_type_declaration
+    type_declaration
     | CR
-    ;
-local_type_declaration :
-    type_specifier ID
-    | type_specifier ID ASSIGN expression
-    | type_specifier array
     ;
 type_specifier :
     U8 | U16 | U32 | U64

--- a/src/apus.y
+++ b/src/apus.y
@@ -11,6 +11,7 @@
 %token<int_val> INT_LITERAL
 %token<double_val> DOUBLE_LITERAL
 %token<char_val> CHAR_LITERAL
+%token<str_val> STRING_LITERAL
 %token<str_val> ID
 
 %token<int_val> U8 U16 U32 U64
@@ -21,7 +22,7 @@
 %token STRUCT CONST UNION
 
 %token L_BRACE R_BRACE L_CASE R_CASE OPEN CLOSE
-%token COMMENT CR QUO DOT VAR SEMI
+%token COMMENT CR DOT VAR SEMI COMMA
 %token INCLUDE IF ELSE FOR EXIT TRUE FALSE RETURN
 
 %right ASSIGN ADDASSIGN SUBASSIGN MULASSIGN DIVASSIGN MODASSIGN ORASSIGN ANDASSIGN XORASSIGN LSASSIGN RSASSIGN
@@ -99,6 +100,8 @@ primary_expression :
     OPEN expression CLOSE
     | INT_LITERAL
     | DOUBLE_LITERAL
+    | CHAR_LITERAL
+    | STRING_LITERAL
     ;
 union_declaration :
     UNION ID block_start local_declaration_list R_BRACE

--- a/src/apus.y
+++ b/src/apus.y
@@ -25,6 +25,8 @@
 %token INCLUDE IF ELSE FOR EXIT TRUE FALSE RETURN
 
 %right ASSIGN
+%left LOR
+%left LAND
 %left OR
 %left XOR
 %left AND
@@ -65,7 +67,9 @@ array :
     | L_CASE expression R_CASE ID ASSIGN expression
     ;
 expression :
-    expression OR expression
+    expression LOR expression
+    | expression LAND expression
+    | expression OR expression
     | expression XOR expression
     | expression AND expression
     | expression EQL expression

--- a/src/apus.y
+++ b/src/apus.y
@@ -24,14 +24,19 @@
 %token COMMENT CR QUO DOT VAR SEMI
 %token INCLUDE IF ELSE FOR EXIT TRUE FALSE RETURN
 
-%left AND OR
+%right ASSIGN
+%left OR
+%left XOR
+%left AND
 %left EQL NEQ
 %left LSS GTR LEQ GEQ
 %left LSHIFT RSHIFT
 %left ADD SUB
 %left MUL DIV MOD
-%right ASSIGN ADDASSIGN SUBASSIGN MULASSIGN DIVASSIGN MODASSIGN NOT
-%type<int_val> type_declaration local_type_declaration expression
+%right NOT REVERSE
+
+%type<int_val> type_declaration local_type_declaration
+%type<int_val> expression unary_expression primary_expression
 %%
 program :
     declaration_list
@@ -60,7 +65,35 @@ array :
     | L_CASE expression R_CASE ID ASSIGN expression
     ;
 expression :
-    INT_LITERAL
+    expression OR expression
+    | expression XOR expression
+    | expression AND expression
+    | expression EQL expression
+    | expression NEQ expression
+    | expression LSS expression
+    | expression GTR expression
+    | expression LEQ expression
+    | expression GEQ expression
+    | expression LSHIFT expression
+    | expression RSHIFT expression
+    | expression ADD expression
+    | expression SUB expression
+    | expression MUL expression
+    | expression DIV expression
+    | expression MOD expression
+    | unary_expression
+    ;
+unary_expression :
+    primary_expression
+    | NOT unary_expression
+    | REVERSE unary_expression
+    | SUB primary_expression
+    | ADD primary_expression
+    ;
+primary_expression :
+    OPEN expression CLOSE
+    | INT_LITERAL
+    | DOUBLE_LITERAL
     ;
 union_declaration :
     UNION ID L_BRACE local_declaration_list R_BRACE


### PR DESCRIPTION
apus.y파일에 expression을 추가하였습니다.
expression의 우선순위와 결합방식을 %left , %right 로 결정합니다.
또한,

assignment operation ( ==, !=, += ...)
- char 타입 : ' '
- string 타입 : " "

을 추가한 상태이고 이전의 PR에서 수정된 사항으로는
- assignment operator(ASSIGN을 제외한 나머지) 추가하는 부분의 commit을 나눔
- local_type_declaration 제거하는 commit을 따로 나눔
- 실수지원 가능하게 정의
- 잘못된 commit 제목 및 내용 수정
- array 미포함

입니다.
