### PR TITLE
parser: Fixed grammar-v1

### DIFF
--- a/src/apus.l
+++ b/src/apus.l
@@ -85,7 +85,7 @@ int yywrap(void) {
 ")"  { return CLOSE; }
 "\n" { return CR; }
 
-[1-9][0-9]* {
+([1-9][0-9]*|[0]) {
     int temp;
     sscanf(yytext, "%d", &temp);
     yylval.int_val = temp;
@@ -97,7 +97,7 @@ int yywrap(void) {
     yylval.double_val = temp;
     return DOUBLE_LITERAL;
 }
-[a-z]+[0-9a-z_]* {
+[a-zA-Z_][0-9a-zA-Z_]* {
     yylval.str_val = malloc(yyleng);
     sprintf(yylval.str_val, "%s", yytext);
     // Sting control : yytext[NUM] 

--- a/src/apus.y
+++ b/src/apus.y
@@ -40,25 +40,51 @@
 
 %%
 program :
-    declaration_list
+    data_declaration_opt action_declaration_opt
     ;
-declaration_list : 
-    declaration
-    | declaration declaration_list
+data_declaration_opt :
+    /* empty */
+    | data_declaration_list
     ;
-declaration : 
+action_declaration_opt :
+    /* empty */
+    | action_declaration_list
+    ;
+line_opt :
+    /* empty */
+    | line_list
+    ;
+line_list :
+    CR
+    | CR line_list
+    ;
+data_declaration_list :
     data_declaration
-    | action_declaration
+    | data_declaration data_declaration_list
+    | line_list data_declaration_list
+    ;
+action_declaration_list :
+    action_declaration
+    | action_declaration action_declaration_list
     ;
 data_declaration :
-    union_declaration
-    | struct_declaration
-    | CR
+    struct_union_type ID block_start member_definition_list R_BRACE line_list
     ;
-type_declaration :
+struct_union_type :
+    STRUCT
+    | UNION
+    ;
+member_definition_list :
+    member_definition line_opt
+    | member_definition line_list member_definition_list
+    ;
+member_definition :
     type_specifier ID
+    | struct_union_type ID ID
     | type_specifier ID ASSIGN expression
+    | struct_union_type ID ID ASSIGN expression
     | type_specifier array
+    | struct_union_type ID array
     ;
 array :
     L_CASE expression R_CASE ID
@@ -101,23 +127,8 @@ primary_expression :
     | STRING_LITERAL
     | ID
     ;
-union_declaration :
-    UNION ID block_start local_declaration_list R_BRACE
-    ;
-struct_declaration :
-    STRUCT ID block_start local_declaration_list R_BRACE
-    ;
 block_start :
-    L_BRACE
-    | CR L_BRACE
-    ;
-local_declaration_list :
-    local_declaration
-    | local_declaration local_declaration_list
-    ;
-local_declaration :
-    type_declaration
-    | CR
+    line_opt L_BRACE line_opt
     ;
 type_specifier :
     U8 | U16 | U32 | U64

--- a/src/apus.y
+++ b/src/apus.y
@@ -16,7 +16,7 @@
 
 %token<int_val> U8 U16 U32 U64
 %token<int_val> S8 S16 S32 S64
-%token<double_cal> F32 F64
+%token<double_val> F32 F64
 %token<char_val> C8 C16 C32
 %token<str_val> STR STR8 STR16 STR32
 %token STRUCT CONST UNION
@@ -38,8 +38,6 @@
 %left MUL DIV MOD
 %right NOT REVERSE
 
-%type<int_val> type_declaration local_type_declaration
-%type<int_val> expression unary_expression primary_expression
 %%
 program :
     declaration_list
@@ -53,9 +51,8 @@ declaration :
     | action_declaration
     ;
 data_declaration :
-    VAR union_declaration
-    | VAR struct_declaration
-    | VAR type_declaration
+    union_declaration
+    | struct_declaration
     | CR
     ;
 type_declaration :
@@ -102,6 +99,7 @@ primary_expression :
     | DOUBLE_LITERAL
     | CHAR_LITERAL
     | STRING_LITERAL
+    | ID
     ;
 union_declaration :
     UNION ID block_start local_declaration_list R_BRACE

--- a/test/parser/Makefile
+++ b/test/parser/Makefile
@@ -1,0 +1,32 @@
+CC = g++
+AR = ar
+
+TEST_DIR = ..
+GTEST_DIR = $(TEST_DIR)/gtest
+YACC_DIR = $(TEST_DIR)/../src
+
+TEST_SRC = $(wildcard *.cpp)
+TEST_OBJ = $(TEST_SRC:.cpp=.o)
+TEST_EXE = unit_test
+
+CFLAGS = -pthread -g
+LDFLAGS = -I$(TEST_DIR)
+
+all: $(TEST_EXE)
+	./$(TEST_EXE)
+
+$(TEST_EXE): $(TEST_OBJ) $(YACC_DIR)/y.tab.o $(YACC_DIR)/lex.yy.o libgtest_main.a
+	$(CC) -o $@ $(CFLAGS) $(LDFLAGS) $^
+
+$(TEST_OBJ): %.o: %.cpp ${GTEST_DIR}/gtest.h
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ -c $<
+
+# make libgtest_main.a, which is a static library that contains gtest code
+libgtest_main.a: $(GTEST_DIR)/gtest-all.cc $(GTEST_DIR)/gtest_main.cc $(GTEST_DIR)/gtest.h
+	$(CC) $(CFLAGS) $(LDFLAGS) -c $(GTEST_DIR)/gtest-all.cc
+	$(CC) $(CFLAGS) $(LDFLAGS) -c $(GTEST_DIR)/gtest_main.cc
+	$(AR) -rv libgtest_main.a gtest-all.o gtest_main.o
+
+# clean all intermidate files and executable file
+clean:
+	rm -rf *.o $(TEST_EXE) libgtest_main.a

--- a/test/parser/data_decl_test.cpp
+++ b/test/parser/data_decl_test.cpp
@@ -1,0 +1,40 @@
+#include "gtest/gtest.h"
+
+extern "C" int yyparse(void);
+extern "C" FILE *yyin;
+static char data_decl_test[] = "\
+struct id {\n\
+    u8 aa\n\
+    f32 bb = 8 + -1\n\
+}\n\
+\n\
+struct id2\n\
+{\n\
+    s8 aa = (4+1)-1 * 3 % 4 << 3 >> 29 * 0\n\
+    str bb = \"string string\"\n\
+}\n\
+\n\
+struct id3 { c8 aa = 'a' }\n\
+\n\
+union id4 {\n\
+    u8 aa\n\
+    f32 bb = 3.8 * 9\n\
+}\n\
+\n\
+union id5\n\
+{\n\
+    u8 aa\n\
+    struct id bb\n\
+}\n\
+\n\
+\n\
+union id6 { u32 aa }\n\
+";
+
+TEST (ParserTest, DataDeclTest) {
+    FILE *testfile = fmemopen(data_decl_test, sizeof(data_decl_test), "r");
+    yyin = testfile;
+    int result = yyparse();
+
+    EXPECT_EQ (result, 0);
+}


### PR DESCRIPTION
1. 사소한 실수들 수정
   - int형에 0이 포함되지 않았던 부분 수정
   - ID의 첫번째 시작글자는 ( a-z, A-Z, _ )로만 시작할 수 있게 수정
   - data_declaration에 VAR과 type_declaration 제거
2. Bison문법 수정
   - line_opt, line_list 를 통해, 문장의 끝을 CR로 처리
   - struct나 union은 소스코드 처음 시작할때만 정의할 수 있게 처리
3. 테스트코드 추가
   - struct와 union의 정의 테스트
   - 간단한 사칙연산의 expression 테스트
