### PR TITLE
Readme: Show build status of master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/swmaestro06-apus/apus.svg)](https://travis-ci.org/swmaestro06-apus/apus)
+[![Build Status](https://travis-ci.org/swmaestro06-apus/apus.svg?branch=master)](https://travis-ci.org/swmaestro06-apus/apus)
 
 # apus
 


### PR DESCRIPTION
브랜치가 명시되어있지 않을경우 다른 브랜치의 빌드 내용이 master에 표시 됩니다. 빌드 상태 링크를 master 브랜치를 명시하도록 수정했습니다.
