### PR TITLE
Travis: Added g++4.8 install script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,11 @@
 language: cpp
 
+sudo: true
+
+install:
+  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+  - sudo apt-get update -qq
+  - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; fi
+  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+
 script: cmake ./ && make


### PR DESCRIPTION
gcc 4.8버전 이하에서 최신 표준을 지원하지 못해, 트레비스에서만 빌드 오류가 납니다. 이를 해결하기 위해서 g++ 설치 스크립트를 추가했습니다.
