### PR TITLE
common: modify type specifier enumeration type

### DIFF
--- a/include/common/common.h
+++ b/include/common/common.h
@@ -14,17 +14,18 @@ namespace apus {
         BIG = 0x01020304ul,
     } Endian;
 
-    enum TypeSpecifier {
+    typedef enum {
         U8, U16, U32, U64,  // Unsigned Integer
         S8, S16, S32, S64,  // Signed Integer
         F32, F64,           // Floating Point Real Number
         C8, C16, C32,       // Character Type
         STR8, STR16, STR32, // String Type
-    };
+        STRUCT, UNION,      // Struct and Union
+        USER_DEFINED,       // User-defined type
+        NOT_DEFINED,        // Not-defined type
+    } TypeSpecifier;
 
-    typedef enum TypeSpecifier VarType;
-
-    int TypeLength(VarType type);
+    int TypeLength (TypeSpecifier type);
 
     inline int HostEndian() {
 

--- a/include/utils/BinaryReader.h
+++ b/include/utils/BinaryReader.h
@@ -20,21 +20,21 @@ namespace apus {
 
         void SetFileEndian(Endian endian);
 
-        int ReadInt(streampos offset, VarType type, uint64_t &out_int);
+        int ReadInt(streampos offset, TypeSpecifier type, uint64_t &out_int);
 
-        int ReadInt(VarType type, uint64_t &out_int);
+        int ReadInt(TypeSpecifier type, uint64_t &out_int);
 
-        int ReadReal(streampos offset, VarType type, double &out_real);
+        int ReadReal(streampos offset, TypeSpecifier type, double &out_real);
 
-        int ReadReal(VarType type, double &out_real);
+        int ReadReal(TypeSpecifier type, double &out_real);
 
-        int ReadChar(streampos offset, VarType type, uint32_t &out_char);
+        int ReadChar(streampos offset, TypeSpecifier type, uint32_t &out_char);
 
-        int ReadChar(VarType type, uint32_t &out_char);
+        int ReadChar(TypeSpecifier type, uint32_t &out_char);
 
-        int ReadString(streampos offset, VarType type, string &out_str);
+        int ReadString(streampos offset, TypeSpecifier type, string &out_str);
 
-        int ReadString(VarType type, string &out_str);
+        int ReadString(TypeSpecifier type, string &out_str);
 
     private:
         string file_name_;                  // file name

--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -4,7 +4,7 @@ using namespace std;
 
 namespace apus {
 
-    int TypeLength(VarType type) {
+    int TypeLength(TypeSpecifier type) {
         int length = 0;
         switch (type) {
             case U8:
@@ -37,8 +37,8 @@ namespace apus {
             case STR32:
                 length = 0; // not fixed. variable-length
                 break;
-
-                // exception
+                
+            // exception
             default:
                 cout << "There's no matched variable type." << endl;
                 length = -1;

--- a/src/utils/BinaryReader.cpp
+++ b/src/utils/BinaryReader.cpp
@@ -57,7 +57,7 @@ namespace apus {
         }
     }
 
-    int BinaryReader::ReadInt(streampos pos, VarType type, uint64_t &out_int) {
+    int BinaryReader::ReadInt(streampos pos, TypeSpecifier type, uint64_t &out_int) {
 
         // If it's not proper type, return -1
         if (type != U8 && type != U16 && type != U32 && type != U64 &&
@@ -86,12 +86,12 @@ namespace apus {
         return 0;
     }
 
-    int BinaryReader::ReadInt(VarType type, uint64_t &out_int) {
+    int BinaryReader::ReadInt(TypeSpecifier type, uint64_t &out_int) {
 
         return ReadInt(file_stream_.tellg(), type, out_int);
     }
 
-    int BinaryReader::ReadReal(streampos pos, VarType type, double &out_real) {
+    int BinaryReader::ReadReal(streampos pos, TypeSpecifier type, double &out_real) {
 
         // If it's not proper type, return -1
         if (type != F32 && type != F64) {
@@ -124,12 +124,12 @@ namespace apus {
         return 0;
     }
 
-    int BinaryReader::ReadReal(VarType type, double &out_real) {
+    int BinaryReader::ReadReal(TypeSpecifier type, double &out_real) {
 
         return ReadReal(file_stream_.tellg(), type, out_real);
     }
 
-    int BinaryReader::ReadChar(streampos pos, VarType type,
+    int BinaryReader::ReadChar(streampos pos, TypeSpecifier type,
                                uint32_t &out_char) {
 
         // If it's not proper type, return -1
@@ -159,15 +159,15 @@ namespace apus {
         return 0;
     }
 
-    int BinaryReader::ReadChar(VarType type, uint32_t &out_char) {
+    int BinaryReader::ReadChar(TypeSpecifier type, uint32_t &out_char) {
 
         return ReadChar(file_stream_.tellg(), type, out_char);
     }
 
-    int BinaryReader::ReadString(streampos pos, VarType type, string &out_str) {
+    int BinaryReader::ReadString(streampos pos, TypeSpecifier type, string &out_str) {
 
         uint32_t read = 0;                  // read character
-        VarType char_type;                  // type of a character
+        TypeSpecifier char_type;                  // type of a character
 
         // assign type of a character
         if (type == STR8) {
@@ -201,9 +201,8 @@ namespace apus {
         return 0;
     }
 
-    int BinaryReader::ReadString(VarType type, string &out_char) {
+    int BinaryReader::ReadString(TypeSpecifier type, string& out_char) {
 
-        return ReadString(file_stream_.tellg(), type, out_char);
+        return ReadString (file_stream_.tellg(), type, out_char);
     }
 }
-

--- a/test/utils/BinaryReader_unit_test.cpp
+++ b/test/utils/BinaryReader_unit_test.cpp
@@ -1,7 +1,6 @@
 #include "gtest/gtest.h"
 #include "utils/BinaryReader.h"
 #include <limits.h>
-
 using namespace apus;
 
 TEST (BinaryReaderTest, ReadIntUnsignedIntegerTest) {


### PR DESCRIPTION
기존에 VarType으로 typedef되어 있던 enumeration type의 이름을 TypeSpecifier로 변경하였고, STRUCT와 UNION타입을 이 열거형 타입에 추가하였습니다. 이름을 변경한탓에 VarType을 사용하고 있던 소스들을 전부 TypeSpecifier를 사용하도록 변경하였습니다.
