### PR TITLE
VM: Added 'ExpressionStatement' and 'VarDefStatement'

### DIFF
--- a/include/ast/statement/expression_statement.h
+++ b/include/ast/statement/expression_statement.h
@@ -1,0 +1,27 @@
+#ifndef EXPRESSION_STATEMENT_H_
+#define EXPRESSION_STATEMENT_H_
+
+#include <memory>
+#include "ast/statement/statement.h"
+
+namespace apus {
+
+    class Expression;
+    class Context;
+
+    class ExpressionStatement : public Statement {
+    public:
+        ExpressionStatement(std::shared_ptr<Expression> expression);
+        virtual ~ExpressionStatement();
+
+        virtual void Execute(Context& context) override;
+
+    private:
+
+        std::shared_ptr<Expression> expression_;
+
+    };
+
+}
+
+#endif

--- a/include/ast/statement/var_def_statement.h
+++ b/include/ast/statement/var_def_statement.h
@@ -1,0 +1,24 @@
+#ifndef VAR_DEF_STATEMENT_H_
+#define VAR_DEF_STATEMENT_H_
+
+#include "ast/statement/statement.h"
+
+namespace apus {
+
+    class Context;
+
+    class VarDefStatement : public Statement {
+    public:
+
+        VarDefStatement();
+        virtual ~VarDefStatement();
+
+        void Execute(Context& context) override;
+
+    private:
+
+    };
+
+}
+
+#endif

--- a/src/ast/statement/expression_statement.cpp
+++ b/src/ast/statement/expression_statement.cpp
@@ -1,0 +1,21 @@
+#include "ast/statement/expression_statement.h"
+#include "ast/expression.h"
+
+#include "vm/context.h"
+
+namespace apus {
+
+    ExpressionStatement::ExpressionStatement(
+            std::shared_ptr<Expression> expression)
+        : expression_(expression) {
+
+    }
+
+    ExpressionStatement::~ExpressionStatement() {
+
+    }
+
+    void ExpressionStatement::Execute(Context& context) {
+        expression_->Evaluate(context);
+    }
+}

--- a/src/ast/statement/var_def_statement.cpp
+++ b/src/ast/statement/var_def_statement.cpp
@@ -1,0 +1,18 @@
+#include "ast/statement/var_def_statement.h"
+#include "vm/context.h"
+
+namespace apus {
+
+    VarDefStatement::VarDefStatement() {
+
+    }
+
+    VarDefStatement::~VarDefStatement() {
+
+    }
+
+    void VarDefStatement::Execute(Context& context) {
+
+    }
+
+}


### PR DESCRIPTION
문법상 필요한 ExpressionStatement와 VarDafStatement를 추가했습니다.

ExpressionStatement
단순히 수식 하나만 가지고 있는 Statement 입니다. 문법상 expression_statement non-terminal에 대응합니다. Execute내부에서 단순히 가지고 있는 expression을 Evaluate합니다.

VarDefStatement
변수 선언 을 수행하는 Statement 입니다. 문법상 var_def_statement에 대응합니다. 아직 변수 테이블이 없기 때문에 비어있습니다.
