### PR TITLE
Test: Added missing 'remove' function at the end of the test

### DIFF
--- a/test/utils/BinaryReader_unit_test.cpp
+++ b/test/utils/BinaryReader_unit_test.cpp
@@ -197,5 +197,7 @@ TEST (BinaryReaderTest, EndianTest) {
             EXPECT_EQ ((int)read, expected_little);
         }
     }
+
+    remove(filename.c_str());
 }
 


### PR DESCRIPTION
BinaryReader_unit_test.cpp의 마지막 테스트에서 파일을 생성하고 지우지 않는 문제 해결 
