### PR TITLE
parser: array-v3

### DIFF
--- a/src/apus.l
+++ b/src/apus.l
@@ -76,6 +76,7 @@
 "!"  { return NOT; }
 "."  { return DOT; }
 ";"  { return SEMI; }
+","  { return COMMA; }
 
 "{"  { return L_BRACE; }
 "}"  { return R_BRACE; }

--- a/test/parser/array_test.cpp
+++ b/test/parser/array_test.cpp
@@ -1,0 +1,69 @@
+#include "gtest/gtest.h"
+
+extern int yyparse(void);
+extern int yy_scan_string(const char *);
+
+// test_x x number is defined sub test
+// 1 : corrected test
+// 2 : uncorrected test
+// 3 : CR test
+
+static char one_dimension_test_1[] = "\
+var u8[1] aa\n\
+var u8[2] bb = [1, 2]\n\
+var struct id2[2] cc = [{1, 2}, {3, 4}]\n\
+";
+
+static char two_dimension_test_1[] = "\
+var u8[1][2] dd\n\
+var u8[2][2] ee = [[1, 2], [3, 4]]\n\
+var struct id2[2][2] ff = [[{1, 2}, {3, 4}], [{5, 6}, {7, 8}]]\n\
+";
+
+static char three_dimension_test_1[] = "\
+var u8[1][2][3] gg\n\
+var u8[2][2][2] hh = [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]\n\
+var struct id2[2][2][2] ii = [[[{1, 2}, {3, 4}], [{5, 6}, {7, 8}]], [[{1, 2}, {3, 4}], [{5, 6}, {7, 8}]]]\n\
+";
+
+static char used_array_test_1[] = "\
+aa = aa[1][2] + bb\n\
+a[1][2] = aa[1][2][3] + bb\n\
+";
+
+static char three_dimension_test_3[] = "\
+var u8[2] jj = [1,\n\
+                2]\n\
+var u8[2][2] kk = [[1, 2],\n\
+                   [3, 4]]\n\
+var struct id2[2][2][2] ll = [[[{1, 2}, {3, 4}], [{5, 6}, {7, 8}]],\n\
+                              [[{9, 0}, {1, 2}], [{3, 4}, {5, 6}]]]\n\
+";
+
+TEST (ParserTest, ArrayCorrectTest) {
+    int result;
+
+    yy_scan_string(one_dimension_test_1);
+    result = yyparse();
+    EXPECT_EQ (result, 0);
+
+    yy_scan_string(two_dimension_test_1);
+    result = yyparse();
+    EXPECT_EQ (result, 0);
+
+    yy_scan_string(three_dimension_test_1);
+    result = yyparse();
+    EXPECT_EQ (result, 0);
+
+    yy_scan_string(used_array_test_1);
+    result = yyparse();
+    EXPECT_EQ (result, 0);
+}
+
+TEST (ParserTest, ArrayCRTest) {
+    int result;
+
+    yy_scan_string(three_dimension_test_3);
+    result = yyparse();
+    EXPECT_EQ (result, 0);
+}

--- a/test/parser/data_decl_test.cpp
+++ b/test/parser/data_decl_test.cpp
@@ -6,12 +6,12 @@ extern int yy_scan_string(const char *);
 static char data_decl_test[] = "\
 struct id {\n\
     u8 aa\n\
-    f32 bb = 8 + -1\n\
+    f32 bb = 8\n\
 }\n\
 \n\
 struct id2\n\
 {\n\
-    s8 aa = (4+1)-1 * 3 % 4 << 3 >> 29 * 0\n\
+    s8 aa = 0\n\
     str bb = \"string string\"\n\
 }\n\
 \n\
@@ -19,7 +19,7 @@ struct id3 { c8 aa = 'a' }\n\
 \n\
 union id4 {\n\
     u8 aa\n\
-    f32 bb = 3.8 * 9\n\
+    f32 bb = 3.8\n\
 }\n\
 \n\
 union id5\n\


### PR DESCRIPTION
배열문법이 추가되었습니다.
- 배열 초기화를 위한 comma 추가
- 1차원 ~ 고차원 배열 지원
- struct_init_list 를 추가하여 block_stmt와 struct_literal간 모호성을 제거

v3

const_expr, init_expr을 추가하여
  member_definition과 variable_definition을 구분.
