### PR TITLE
VM: Value: Added derived classes of 'Value'

### DIFF
--- a/include/ast/value/character_value.h
+++ b/include/ast/value/character_value.h
@@ -1,0 +1,43 @@
+#ifndef CHARACTER_VALUE_H_
+#define CHARACTER_VALUE_H_
+
+#include <memory>
+#include "value.h"
+#include "common/common.h"
+
+namespace apus {
+
+    class CharacterValue : public Value {
+    public:
+        CharacterValue(TypeSpecifier type, int32_t value)
+            : Value(type, std::make_shared<int32_t>(value)) {
+        }
+
+        CharacterValue(TypeSpecifier type, std::shared_ptr<void> value_ptr)
+            : Value(type, value_ptr) {
+        }
+
+        virtual ~CharacterValue() {}
+
+        virtual std::shared_ptr<Value> Copy() const {
+            return std::make_shared<CharacterValue>(type_, value_);
+        }
+
+        virtual std::shared_ptr<Value> Promote(
+                const std::shared_ptr<Value> another) const override;
+
+        virtual std::shared_ptr<Value> OperateBinary(
+                const Expression::Type expression_type,
+                const std::shared_ptr<Value>& right) const override;
+
+        virtual std::shared_ptr<Value> OperateUnary(
+                const Expression::Type expression_type) const override;
+
+        int32_t getCharacterValue() const {
+            return *((int32_t *)value_.get());
+        }
+    };
+
+}
+
+#endif

--- a/include/ast/value/float_value.h
+++ b/include/ast/value/float_value.h
@@ -1,0 +1,42 @@
+#ifndef FLOAT_VALUE_H_
+#define FLOAT_VALUE_H_
+
+#include <memory>
+#include "value.h"
+#include "common/common.h"
+
+namespace apus {
+
+    class FloatValue : public Value {
+    public:
+        FloatValue(TypeSpecifier type, double value)
+            : Value(type, std::make_shared<double>(value)) {
+        }
+
+        FloatValue(TypeSpecifier type, std::shared_ptr<void> value_ptr)
+            : Value(type, value_ptr) {
+        }
+
+        virtual ~FloatValue() {}
+
+        virtual std::shared_ptr<Value> Copy() const {
+            return std::make_shared<FloatValue>(type_, value_);
+        }
+        virtual std::shared_ptr<Value> Promote(
+                const std::shared_ptr<Value> another) const override;
+
+        virtual std::shared_ptr<Value> OperateBinary(
+                const Expression::Type expression_type,
+                const std::shared_ptr<Value>& right) const override;
+
+        virtual std::shared_ptr<Value> OperateUnary(
+                const Expression::Type expression_type) const override;
+
+        double getFloatValue() const {
+            return *((double *)value_.get());
+        }
+    };
+
+}
+
+#endif

--- a/include/ast/value/signed_int_value.h
+++ b/include/ast/value/signed_int_value.h
@@ -1,0 +1,44 @@
+#ifndef SIGNED_INT_VALUE_H_
+#define SIGNED_INT_VALUE_H_
+
+#include <memory>
+#include "value.h"
+#include "common/common.h"
+
+namespace apus {
+
+    class SignedIntValue : public Value {
+    public:
+        SignedIntValue(TypeSpecifier type, int64_t value)
+            : Value(type, std::make_shared<int64_t>(value)) {
+        }
+
+        SignedIntValue(TypeSpecifier type, std::shared_ptr<void> value_ptr)
+            : Value(type, value_ptr) {
+        }
+
+        virtual ~SignedIntValue() {}
+
+        virtual std::shared_ptr<Value> Copy() const override {
+            return std::make_shared<SignedIntValue>(type_, value_);
+        }
+
+        virtual std::shared_ptr<Value> Promote(
+                const std::shared_ptr<Value> another) const override;
+
+        virtual std::shared_ptr<Value> OperateBinary(
+                const Expression::Type expression_type,
+                const std::shared_ptr<Value>& right) const override;
+
+        virtual std::shared_ptr<Value> OperateUnary(
+                const Expression::Type expression_type) const override;
+
+        inline int64_t getIntValue() const {
+            return *((int64_t *)value_.get());
+        }
+
+    };
+
+}
+
+#endif

--- a/include/ast/value/string_value.h
+++ b/include/ast/value/string_value.h
@@ -1,0 +1,46 @@
+#ifndef STRING_VALUE_H_
+#define STRING_VALUE_H_
+
+#include <string>
+#include <memory>
+
+#include "value.h"
+#include "common/common.h"
+
+namespace apus {
+
+    class Value;
+
+    class StringValue : public Value {
+    public:
+        StringValue(TypeSpecifier type, std::string value)
+            : Value(type, std::make_shared<std::string>(value)) {}
+
+        StringValue(TypeSpecifier type, std::shared_ptr<void> value_ptr)
+            : Value(type, value_ptr) {
+        }
+
+        virtual ~StringValue() {}
+
+        virtual std::shared_ptr<Value> Copy() const {
+            return std::make_shared<StringValue>(type_, value_);
+        }
+
+        virtual std::shared_ptr<Value> Promote(
+                const std::shared_ptr<Value> another) const override;
+
+        virtual std::shared_ptr<Value> OperateBinary(
+                const Expression::Type expression_type,
+                const std::shared_ptr<Value>& right) const override;
+
+        virtual std::shared_ptr<Value> OperateUnary(
+                const Expression::Type expression_type) const override;
+
+        std::string getStringValue() const {
+            return *((std::string *)value_.get());
+        }
+    };
+
+}
+
+#endif

--- a/include/ast/value/unsigned_int_value.h
+++ b/include/ast/value/unsigned_int_value.h
@@ -1,0 +1,42 @@
+#ifndef UNSIGNED_INT_VALUE_H_
+#define UNSIGNED_INT_VALUE_H_
+
+#include <memory>
+#include "signed_int_value.h"
+
+namespace apus {
+
+    class UnsignedIntValue : public SignedIntValue {
+    public:
+        UnsignedIntValue(TypeSpecifier type, uint64_t value)
+            : SignedIntValue(type, value) {}
+
+        UnsignedIntValue(TypeSpecifier type, std::shared_ptr<void> value_ptr)
+            : SignedIntValue(type, value_ptr) {
+        }
+
+        virtual ~UnsignedIntValue() {}
+
+        virtual std::shared_ptr<Value> Copy() const {
+            return std::make_shared<UnsignedIntValue>(type_, value_);
+        }
+
+        virtual std::shared_ptr<Value> Promote(
+                const std::shared_ptr<Value> another) const override;
+
+        virtual std::shared_ptr<Value> OperateBinary(
+                const Expression::Type expression_type,
+                const std::shared_ptr<Value>& right) const override;
+
+        virtual std::shared_ptr<Value> OperateUnary(
+                const Expression::Type expression_type) const override;
+
+        uint64_t getUIntValue() const {
+            return (uint64_t)SignedIntValue::getIntValue();
+        }
+
+    };
+
+}
+
+#endif

--- a/include/ast/value/value.h
+++ b/include/ast/value/value.h
@@ -12,26 +12,34 @@ namespace apus {
     class Value {
     public:
 
-        Value(TypeSpecifier type) : type_(type) {}
+        Value(TypeSpecifier type, std::shared_ptr<void> value)
+            : type_(type), value_(value) {}
         virtual ~Value(){}
 
-        // returns type of current object
         virtual TypeSpecifier getType() const { return type_; };
+
+        virtual std::shared_ptr<void> getValue() const { return value_; }
+
+        int getSize() const { return TypeLength(type_); }
 
         // Deep Copy function
         inline virtual std::shared_ptr<Value> Copy() const { return nullptr; }
 
-        int getSize() const { return TypeLength(type_); }
+        virtual std::shared_ptr<Value> Promote(
+                const std::shared_ptr<Value> another) const = 0;
 
-        virtual std::shared_ptr<Value> Promote(const Value& another) const = 0;
-
-        virtual std::shared_ptr<Value> Operate(
+        virtual std::shared_ptr<Value> OperateBinary(
                 const Expression::Type expression_type,
-                const std::shared_ptr<Value>& right) const { return nullptr; }
+                const std::shared_ptr<Value>& right) const = 0;
+
+        virtual std::shared_ptr<Value> OperateUnary(
+                const Expression::Type expression_type) const = 0;
 
     protected:
 
-        TypeSpecifier type_;
+        TypeSpecifier           type_;
+        std::shared_ptr<void>   value_;
+
     };
 
 }

--- a/src/ast/expression.cpp
+++ b/src/ast/expression.cpp
@@ -40,10 +40,28 @@ namespace apus {
 
         std::shared_ptr<Value> result = nullptr;
 
-        std::shared_ptr<Value> lValue = left_expression_->Evaluate(context);
-        std::shared_ptr<Value> rValue = right_expression_->Evaluate(context);
+        // 1. check expression
+        if (left_expression_ != nullptr && right_expression_ != nullptr) {
 
-        result = lValue->Operate(this->getType(), rValue);
+            std::shared_ptr<Value> left_value = left_expression_->Evaluate(context);
+            std::shared_ptr<Value> right_value = right_expression_->Evaluate(context);
+
+            // 2. check lvalue, rvalue
+            if (left_value != nullptr && right_value != nullptr) {
+
+                std::shared_ptr<Value> left_promoted = left_value->Promote(right_value);
+                std::shared_ptr<Value> right_promoted = right_value->Promote(left_value);
+
+                // 3. check promoted values
+                if (left_promoted != nullptr && right_promoted != nullptr) {
+
+                    result = left_promoted->OperateBinary(this->getType(),
+                                                          right_promoted);
+                }
+
+            }
+
+        }
 
         return result;
     }
@@ -71,6 +89,7 @@ namespace apus {
 
         std::shared_ptr<Value> result = nullptr;
         result = expression_->Evaluate(context);
+        result = result->OperateUnary(this->getType());
 
         return result;
     }

--- a/src/ast/value/character_value.cpp
+++ b/src/ast/value/character_value.cpp
@@ -1,0 +1,32 @@
+#include "ast/value/character_value.h"
+
+namespace apus {
+
+    std::shared_ptr<Value> CharacterValue::Promote(
+            const std::shared_ptr<Value> another) const {
+
+        if (type_ == another->getType()) {
+            return this->Copy();
+        }
+
+        return nullptr;
+    }
+
+    std::shared_ptr<Value> CharacterValue::OperateBinary(
+            const Expression::Type expression_type,
+            const std::shared_ptr<Value> &right) const {
+
+        std::shared_ptr<Value> result = nullptr;
+
+        return result;
+    }
+
+    std::shared_ptr<Value> CharacterValue::OperateUnary(
+            const Expression::Type expression_type) const {
+
+        std::shared_ptr<Value> result = nullptr;
+
+        return result;
+    }
+
+}

--- a/src/ast/value/float_value.cpp
+++ b/src/ast/value/float_value.cpp
@@ -1,0 +1,153 @@
+#include <math.h>
+#include "ast/value/float_value.h"
+#include "ast/value/signed_int_value.h"
+
+namespace apus {
+
+    std::shared_ptr<Value> FloatValue::Promote(
+            const std::shared_ptr<Value> another) const {
+
+        // case 1. Exactly same type
+        if (type_ == another->getType()) {
+            return this->Copy();
+        }
+
+        // case 2. Same class but size
+        std::shared_ptr<FloatValue> another_dynamic = nullptr;
+        if ( (another_dynamic = std::dynamic_pointer_cast<FloatValue>(another)) ) {
+
+            TypeSpecifier type = getType() > another_dynamic->getType()
+                                 ? getType()
+                                 : another_dynamic->getType();
+
+            return std::make_shared<FloatValue>(type, this->getValue());
+        }
+
+        // case 3. Different class
+        else {
+
+            // case 3.1 SignedIntValue
+            std::shared_ptr<SignedIntValue> another_siv = nullptr;
+            if( (another_siv = std::dynamic_pointer_cast<SignedIntValue>(another)) ) {
+
+                return this->Copy();
+            }
+
+        }
+
+        return nullptr;
+    }
+
+    std::shared_ptr<Value> FloatValue::OperateBinary(
+            const Expression::Type expression_type,
+            const std::shared_ptr<Value> &right_promoted) const {
+
+        std::shared_ptr<Value> result = nullptr;
+
+        // 'right' value MUST be same type with this's type;
+        if (right_promoted->getType() == this->getType()) {
+
+            std::shared_ptr<FloatValue> right_dynamic = std::dynamic_pointer_cast<FloatValue>(right_promoted);
+
+            double left_value = this->getFloatValue();
+            double right_value = right_dynamic->getFloatValue();
+
+            double result_value = 0;
+            TypeSpecifier type = this->getType();
+
+            switch (expression_type) {
+
+                case Expression::Type::EXP_OR :
+                    return nullptr;
+                case Expression::Type::EXP_AND :
+                    return nullptr;
+
+                case Expression::Type::EXP_EQL :
+                    result_value = left_value == right_value;
+                    break;
+                case Expression::Type::EXP_NEQ :
+                    result_value = left_value != right_value;
+                    break;
+                case Expression::Type::EXP_LSS :
+                    result_value = left_value < right_value;
+                    break;
+                case Expression::Type::EXP_GTR :
+                    result_value = left_value > right_value;
+                    break;
+                case Expression::Type::EXP_LEQ :
+                    result_value = left_value <= right_value;
+                    break;
+                case Expression::Type::EXP_GEQ :
+                    result_value = left_value >= right_value;
+                    break;
+
+                case Expression::Type::EXP_LSHIFT :
+                    return nullptr;
+                case Expression::Type::EXP_RSHIFT :
+                    return nullptr;
+
+                case Expression::Type::EXP_ADD :
+                    result_value = left_value + right_value;
+                    break;
+                case Expression::Type::EXP_SUB :
+                    result_value = left_value - right_value;
+                    break;
+                case Expression::Type::EXP_MUL :
+                    result_value = left_value * right_value;
+                    break;
+                case Expression::Type::EXP_DIV :
+                    result_value = left_value / right_value;
+                    break;
+                case Expression::Type::EXP_MOD :
+                    result_value = fmod(left_value, right_value);
+                    break;
+                case Expression::Type::EXP_XOR :
+                    return nullptr;
+
+                case Expression::Type::EXP_LOR :
+                    result_value = left_value || right_value;
+                    break;
+                case Expression::Type::EXP_LAND :
+                    result_value = left_value && right_value;
+                    break;
+
+                default:
+                    return nullptr;
+            }
+
+            result = std::make_shared<FloatValue>(type, result_value);
+        }
+
+        return result;
+    }
+
+    std::shared_ptr<Value> FloatValue::OperateUnary(
+            const Expression::Type expression_type) const {
+
+        std::shared_ptr<Value> result = nullptr;
+        double result_value = 0;
+
+        switch (expression_type) {
+            case Expression::Type::EXP_NOT :
+                result_value = !(this->getFloatValue());
+                break;
+            case Expression::Type::EXP_REVERSE :
+                // reverse operation not supported
+                return nullptr;
+            case Expression::Type::EXP_SUB :
+                result_value = -(this->getFloatValue());
+                break;
+            case Expression::Type::EXP_ADD :
+                result_value = +(this->getFloatValue());
+                break;
+
+            default:
+                return nullptr;
+        }
+
+        result = std::make_shared<FloatValue>(this->getType(), result_value);
+
+        return result;
+    }
+
+}

--- a/src/ast/value/signed_int_value.cpp
+++ b/src/ast/value/signed_int_value.cpp
@@ -1,0 +1,162 @@
+#include "ast/value/signed_int_value.h"
+#include "ast/expression.h"
+#include "common/common.h"
+
+#include "ast/value/float_value.h"
+
+namespace apus {
+
+    std::shared_ptr<Value> SignedIntValue::Promote(
+            const std::shared_ptr<Value> another) const {
+
+        // PROMOTE THIS, NOT another
+
+        // case 1. Exactly same type
+        if (type_ == another->getType()) {
+            return this->Copy();
+        }
+
+        // case 2. Same class but size
+        std::shared_ptr<SignedIntValue> another_dynamic = nullptr;
+        if ( (another_dynamic = std::dynamic_pointer_cast<SignedIntValue>(another)) ) {
+
+            TypeSpecifier type = getType() > another_dynamic->getType()
+                       ? getType()
+                       : another_dynamic->getType();
+
+            return std::make_shared<SignedIntValue>(type, this->getValue());
+        }
+
+        // case 3. Different class
+        else {
+
+            // case 3.1 FloatValue
+            std::shared_ptr<FloatValue> another_fv = nullptr;
+            if( (another_fv = std::dynamic_pointer_cast<FloatValue>(another)) ) {
+
+                double value = static_cast<double>(this->getIntValue());
+                return std::make_shared<FloatValue>(F64, value);
+            }
+
+        }
+
+        return nullptr;
+    }
+
+    std::shared_ptr<Value> SignedIntValue::OperateBinary(
+            const Expression::Type expression_type,
+            const std::shared_ptr<Value> &right_promoted) const {
+
+        std::shared_ptr<Value> result = nullptr;
+
+        // 'right' value MUST be same type with this's type;
+        if (right_promoted->getType() == this->getType()) {
+
+            std::shared_ptr<SignedIntValue> right_dynamic = std::dynamic_pointer_cast<SignedIntValue>(right_promoted);
+
+            int64_t left_value = this->getIntValue();
+            int64_t right_value = right_dynamic->getIntValue();
+
+            int64_t result_value = 0;
+
+            switch (expression_type) {
+
+                case Expression::Type::EXP_OR :
+                    result_value = left_value | right_value;
+                    break;
+                case Expression::Type::EXP_AND :
+                    result_value = left_value & right_value;
+                    break;
+
+                case Expression::Type::EXP_EQL :
+                    result_value = left_value == right_value;
+                    break;
+                case Expression::Type::EXP_NEQ :
+                    result_value = left_value != right_value;
+                    break;
+                case Expression::Type::EXP_LSS :
+                    result_value = left_value < right_value;
+                    break;
+                case Expression::Type::EXP_GTR :
+                    result_value = left_value > right_value;
+                    break;
+                case Expression::Type::EXP_LEQ :
+                    result_value = left_value <= right_value;
+                    break;
+                case Expression::Type::EXP_GEQ :
+                    result_value = left_value >= right_value;
+                    break;
+
+                case Expression::Type::EXP_LSHIFT :
+                    result_value = left_value << right_value;
+                    break;
+                case Expression::Type::EXP_RSHIFT :
+                    result_value = left_value >> right_value;
+                    break;
+
+                case Expression::Type::EXP_ADD :
+                    result_value = left_value + right_value;
+                    break;
+                case Expression::Type::EXP_SUB :
+                    result_value = left_value - right_value;
+                    break;
+                case Expression::Type::EXP_MUL :
+                    result_value = left_value * right_value;
+                    break;
+                case Expression::Type::EXP_DIV :
+                    result_value = left_value / right_value;
+                    break;
+                case Expression::Type::EXP_MOD :
+                    result_value = left_value % right_value;
+                    break;
+                case Expression::Type::EXP_XOR :
+                    result_value = left_value ^ right_value;
+                    break;
+
+                case Expression::Type::EXP_LOR :
+                    result_value = left_value || right_value;
+                    break;
+                case Expression::Type::EXP_LAND :
+                    result_value = left_value && right_value;
+                    break;
+
+                default:
+                    return nullptr;
+            }
+
+            result = std::make_shared<SignedIntValue>(this->getType(), result_value);
+        }
+
+        return result;
+    }
+
+    std::shared_ptr<Value> SignedIntValue::OperateUnary(
+            const Expression::Type expression_type) const {
+
+        std::shared_ptr<Value> result = nullptr;
+        int64_t result_value = 0;
+
+        switch (expression_type) {
+            case Expression::Type::EXP_NOT :
+                result_value = !(this->getIntValue());
+                break;
+            case Expression::Type::EXP_REVERSE :
+                result_value = ~(this->getIntValue());
+                break;
+            case Expression::Type::EXP_SUB :
+                result_value = -(this->getIntValue());
+                break;
+            case Expression::Type::EXP_ADD :
+                result_value = +(this->getIntValue());
+                break;
+
+                default:
+                    return nullptr;
+        }
+
+        result = std::make_shared<SignedIntValue>(this->getType(), result_value);
+
+        return result;
+    }
+
+}

--- a/src/ast/value/string_value.cpp
+++ b/src/ast/value/string_value.cpp
@@ -1,0 +1,32 @@
+#include "ast/value/string_value.h"
+
+namespace apus {
+
+    std::shared_ptr<Value> StringValue::Promote(
+            const std::shared_ptr<Value> another) const {
+
+        if (type_ == another->getType()) {
+            return this->Copy();
+        }
+
+        return nullptr;
+    }
+
+    std::shared_ptr<Value> StringValue::OperateBinary(
+            const Expression::Type expression_type,
+            const std::shared_ptr<Value> &right) const {
+
+        std::shared_ptr<Value> result = nullptr;
+
+        return result;
+    }
+
+    std::shared_ptr<Value> StringValue::OperateUnary(
+            const Expression::Type expression_type) const {
+
+        std::shared_ptr<Value> result = nullptr;
+
+        return result;
+    }
+
+}

--- a/src/ast/value/unsigned_int_value.cpp
+++ b/src/ast/value/unsigned_int_value.cpp
@@ -1,0 +1,38 @@
+#include "ast/value/unsigned_int_value.h"
+#include "common/common.h"
+
+namespace apus {
+
+    std::shared_ptr<Value> UnsignedIntValue::Promote(
+            const std::shared_ptr<Value> another) const {
+
+        if (type_ == another->getType()) {
+            return this->Copy();
+        }
+
+        return nullptr;
+    }
+
+    std::shared_ptr<Value> UnsignedIntValue::OperateBinary(
+            const Expression::Type expression_type,
+            const std::shared_ptr<Value> &right) const {
+
+        std::shared_ptr<SignedIntValue> result = std::dynamic_pointer_cast<SignedIntValue>(SignedIntValue::OperateBinary(expression_type, right));
+
+        TypeSpecifier type = TypeSpecifier::U64;
+        uint64_t uval = (uint64_t) result->getIntValue();
+
+        std::shared_ptr<UnsignedIntValue> result_unsigned = std::make_shared<UnsignedIntValue>(type, uval);
+
+        return result_unsigned;
+    }
+
+    std::shared_ptr<Value> UnsignedIntValue::OperateUnary(
+            const Expression::Type expression_type) const {
+
+        std::shared_ptr<Value> result = SignedIntValue::OperateUnary(expression_type);
+
+        return result;
+    }
+
+}

--- a/test/ast/ast_test.cpp
+++ b/test/ast/ast_test.cpp
@@ -1,0 +1,90 @@
+#include <list>
+#include <memory>
+
+#include "gtest/gtest.h"
+
+#include "ast/expression.h"
+#include "ast/statement/statement.h"
+
+#include "ast/value/signed_int_value.h"
+#include "ast/value/float_value.h"
+
+#include "vm/context.h"
+
+using namespace apus;
+
+TEST (ASTTest, ExpressionTest1) {
+
+    apus::Context ctx;
+
+    //  nullptr input
+    {
+        std::shared_ptr<Expression> left_expr = nullptr;
+        std::shared_ptr<Expression> right_expr = nullptr;
+        Expression *expr = nullptr;
+
+        expr = new BinaryExpression(Expression::EXP_ADD, left_expr,
+                                    right_expr);
+
+        EXPECT_EQ(nullptr, expr->Evaluate(ctx));
+    }
+
+    // 1 + 2 == 3
+    {
+        std::shared_ptr<Value> left_value = std::make_shared<SignedIntValue>(S32, 1);
+        std::shared_ptr<Expression> left_expr = std::make_shared<ValueExpression>(left_value);
+
+        std::shared_ptr<Value> right_value = std::make_shared<SignedIntValue>(S32, 2);
+        std::shared_ptr<Expression> right_expr = std::make_shared<ValueExpression>(right_value);
+        std::shared_ptr<Expression> expr = std::make_shared<BinaryExpression>(Expression::EXP_ADD, left_expr, right_expr);
+
+        std::shared_ptr<SignedIntValue> result = std::dynamic_pointer_cast<SignedIntValue>(expr->Evaluate(ctx));
+
+        EXPECT_EQ(3, result->getIntValue());
+    }
+
+    // 1 + 2 * 3 == 7
+    {
+        std::shared_ptr<Expression> _1 = std::make_shared<ValueExpression>(std::make_shared<SignedIntValue>(S32, 1));
+        std::shared_ptr<Expression> _2 = std::make_shared<ValueExpression>(std::make_shared<SignedIntValue>(S32, 2));
+        std::shared_ptr<Expression> _3 = std::make_shared<ValueExpression>(std::make_shared<SignedIntValue>(S32, 3));
+
+        std::shared_ptr<Expression> mul_expr = std::make_shared<BinaryExpression>(Expression::EXP_MUL, _2, _3);
+        std::shared_ptr<Expression> add_expr = std::make_shared<BinaryExpression>(Expression::EXP_ADD, _1, mul_expr);
+
+        std::shared_ptr<SignedIntValue> result = std::dynamic_pointer_cast<SignedIntValue>(add_expr->Evaluate(ctx));
+
+        EXPECT_EQ(7, result->getIntValue());
+    }
+
+    // ( 1 + 2 * 3 ) % 5 == 5
+    {
+        std::shared_ptr<Expression> _1 = std::make_shared<ValueExpression>(std::make_shared<SignedIntValue>(S32, 1));
+        std::shared_ptr<Expression> _2 = std::make_shared<ValueExpression>(std::make_shared<SignedIntValue>(S32, 2));
+        std::shared_ptr<Expression> _3 = std::make_shared<ValueExpression>(std::make_shared<SignedIntValue>(S32, 3));
+        std::shared_ptr<Expression> _5 = std::make_shared<ValueExpression>(std::make_shared<SignedIntValue>(S32, 5));
+
+        std::shared_ptr<Expression> mul_expr = std::make_shared<BinaryExpression>(Expression::EXP_MUL, _2, _3);
+        std::shared_ptr<Expression> add_expr = std::make_shared<BinaryExpression>(Expression::EXP_ADD, _1, mul_expr);
+
+        std::shared_ptr<Expression> mod_expr = std::make_shared<BinaryExpression>(Expression::EXP_MOD, add_expr, _5);
+
+        std::shared_ptr<SignedIntValue> result = std::dynamic_pointer_cast<SignedIntValue>(mod_expr->Evaluate(ctx));
+
+        EXPECT_EQ(5, result->getIntValue());
+    }
+
+    // 2 * 3.5 / 3
+    {
+        std::shared_ptr<Expression> _2 = std::make_shared<ValueExpression>(std::make_shared<SignedIntValue>(S64, 2));
+        std::shared_ptr<Expression> _3_5 = std::make_shared<ValueExpression>(std::make_shared<FloatValue>(F64, 3.5));
+        std::shared_ptr<Expression> _3 = std::make_shared<ValueExpression>(std::make_shared<SignedIntValue>(S64, 3));
+
+        std::shared_ptr<Expression> mul_expr = std::make_shared<BinaryExpression>(Expression::EXP_MUL, _2, _3_5);
+        std::shared_ptr<Expression> div_expr = std::make_shared<BinaryExpression>(Expression::EXP_DIV, mul_expr, _3);
+
+        std::shared_ptr<FloatValue> result = std::dynamic_pointer_cast<FloatValue>(div_expr->Evaluate(ctx));
+
+        EXPECT_EQ( (2 * 3.5 / 3) , result->getFloatValue());
+    }
+}


### PR DESCRIPTION
Value클래스를 상속받은 파생클래스들을 만들었습니다. 각 타입마다 클래스를 하나씩 파생시켰습니다. 이들은 yacc에서 지정한 rule과 매치되면 실행하는 action부분에서 트리구조로 생성될 것입니다.

현재 simple_int_value.h, .cpp 파일에만 일부분이 구현이 되어 있지만, Value 클래스를 통해 어떻게 expression을 계산시켜 나갈지 예시로 구현 해놓았습니다. (위키에도 서술함)

현재 구현된 SignedIntValue와 FloatIntValue에 대한 테스트 코드도 추가했습니다.
