### PR TITLE
VM: Value: Added derived classes of 'Value' -v4

### DIFF
--- a/include/ast/expression.h
+++ b/include/ast/expression.h
@@ -132,9 +132,9 @@ namespace apus {
 
     class AssignExpression : public Expression {
     public:
-        AssignExpression(std::string name,
+        AssignExpression(Type type, std::string name,
                          std::shared_ptr<Expression> expression);
-        AssignExpression(char* name, Expression* expression);
+        AssignExpression(Type type, char* name, Expression* expression);
         virtual ~AssignExpression();
 
         virtual std::shared_ptr<Value> Evaluate(Context& context);

--- a/include/ast/value/float_value.h
+++ b/include/ast/value/float_value.h
@@ -1,0 +1,46 @@
+#ifndef FLOAT_VALUE_H_
+#define FLOAT_VALUE_H_
+
+#include <memory>
+#include "value.h"
+#include "common/common.h"
+
+namespace apus {
+
+    class FloatValue : public Value {
+    public:
+        FloatValue(TypeSpecifier type, double value)
+            : Value(type, std::make_shared<double>(value)) {
+        }
+
+        FloatValue(TypeSpecifier type, std::shared_ptr<void> value_ptr)
+            : Value(type, value_ptr) {
+        }
+
+        virtual ~FloatValue() {}
+
+        virtual std::shared_ptr<Value> Copy() const {
+            return std::make_shared<FloatValue>(type_, value_);
+        }
+        virtual std::shared_ptr<Value> Promote(
+                const std::shared_ptr<Value> another) const override;
+
+        virtual std::shared_ptr<Value> OperateBinary(
+                const Expression::Type expression_type,
+                const std::shared_ptr<Value>& right) const override;
+
+        virtual std::shared_ptr<Value> OperateUnary(
+                const Expression::Type expression_type) const override;
+
+        double getFloatValue() const {
+            return *((double *)value_.get());
+        }
+
+    protected:
+
+        double NearlyEqual(double another) const ;
+    };
+
+}
+
+#endif

--- a/include/ast/value/signed_int_value.h
+++ b/include/ast/value/signed_int_value.h
@@ -1,0 +1,44 @@
+#ifndef SIGNED_INT_VALUE_H_
+#define SIGNED_INT_VALUE_H_
+
+#include <memory>
+#include "value.h"
+#include "common/common.h"
+
+namespace apus {
+
+    class SignedIntValue : public Value {
+    public:
+        SignedIntValue(TypeSpecifier type, int64_t value)
+            : Value(type, std::make_shared<int64_t>(value)) {
+        }
+
+        SignedIntValue(TypeSpecifier type, std::shared_ptr<void> value_ptr)
+            : Value(type, value_ptr) {
+        }
+
+        virtual ~SignedIntValue() {}
+
+        virtual std::shared_ptr<Value> Copy() const override {
+            return std::make_shared<SignedIntValue>(type_, value_);
+        }
+
+        virtual std::shared_ptr<Value> Promote(
+                const std::shared_ptr<Value> another) const override;
+
+        virtual std::shared_ptr<Value> OperateBinary(
+                const Expression::Type expression_type,
+                const std::shared_ptr<Value>& right) const override;
+
+        virtual std::shared_ptr<Value> OperateUnary(
+                const Expression::Type expression_type) const override;
+
+        inline int64_t getIntValue() const {
+            return *((int64_t *)value_.get());
+        }
+
+    };
+
+}
+
+#endif

--- a/include/ast/value/value.h
+++ b/include/ast/value/value.h
@@ -12,26 +12,34 @@ namespace apus {
     class Value {
     public:
 
-        Value(TypeSpecifier type) : type_(type) {}
+        Value(TypeSpecifier type, std::shared_ptr<void> value)
+            : type_(type), value_(value) {}
         virtual ~Value(){}
 
-        // returns type of current object
         virtual TypeSpecifier getType() const { return type_; };
+
+        virtual std::shared_ptr<void> getValue() const { return value_; }
+
+        int getSize() const { return TypeLength(type_); }
 
         // Deep Copy function
         inline virtual std::shared_ptr<Value> Copy() const { return nullptr; }
 
-        int getSize() const { return TypeLength(type_); }
+        virtual std::shared_ptr<Value> Promote(
+                const std::shared_ptr<Value> another) const = 0;
 
-        virtual std::shared_ptr<Value> Promote(const Value& another) const = 0;
-
-        virtual std::shared_ptr<Value> Operate(
+        virtual std::shared_ptr<Value> OperateBinary(
                 const Expression::Type expression_type,
-                const std::shared_ptr<Value>& right) const { return nullptr; }
+                const std::shared_ptr<Value>& right) const = 0;
+
+        virtual std::shared_ptr<Value> OperateUnary(
+                const Expression::Type expression_type) const = 0;
 
     protected:
 
-        TypeSpecifier type_;
+        TypeSpecifier           type_;
+        std::shared_ptr<void>   value_;
+
     };
 
 }

--- a/src/ast/expression.cpp
+++ b/src/ast/expression.cpp
@@ -133,14 +133,16 @@ namespace apus {
 
     // AssignExpression::
 
-    AssignExpression::AssignExpression(std::string name,
+    AssignExpression::AssignExpression(Type type,
+                                       std::string name,
                                        std::shared_ptr<Expression> expression)
-        : Expression(EXP_ASSIGN), name_(name), expression_(expression) {
+        : Expression(type), name_(name), expression_(expression) {
 
     }
 
-    AssignExpression::AssignExpression(char* name, Expression* expression) {
-        AssignExpression(std::string(name), std::shared_ptr<Expression>(expression));
+    AssignExpression::AssignExpression(Type type, char* name,
+                                       Expression* expression) {
+        AssignExpression(type, std::string(name), std::shared_ptr<Expression>(expression));
     }
 
     AssignExpression::~AssignExpression() {
@@ -149,9 +151,28 @@ namespace apus {
 
     std::shared_ptr<Value> AssignExpression::Evaluate(Context &context) {
 
-        std::shared_ptr<Value> result = nullptr;
+        if (expression_ != nullptr) {
 
-        return result;
+            // Find left value from the variable table
+            std::shared_ptr<Value> left = nullptr;
+            std::shared_ptr<Value> right = expression_->Evaluate(context);
+
+            if (left != nullptr && right != nullptr) {
+
+                std::shared_ptr<Value> right_promoted = right->Promote(left);
+
+                if (right_promoted != nullptr) {
+
+                    std::shared_ptr<Value> result =
+                            left->OperateBinary(this->getType(), right_promoted);
+
+                    // and, put 'result' value into the variable
+
+                }
+            }
+            return left;
+        }
+        return nullptr;
     }
 
     // MemberExpression::

--- a/src/ast/expression.cpp
+++ b/src/ast/expression.cpp
@@ -40,10 +40,28 @@ namespace apus {
 
         std::shared_ptr<Value> result = nullptr;
 
-        std::shared_ptr<Value> lValue = left_expression_->Evaluate(context);
-        std::shared_ptr<Value> rValue = right_expression_->Evaluate(context);
+        // 1. check expression
+        if (left_expression_ != nullptr && right_expression_ != nullptr) {
 
-        result = lValue->Operate(this->getType(), rValue);
+            std::shared_ptr<Value> left_value = left_expression_->Evaluate(context);
+            std::shared_ptr<Value> right_value = right_expression_->Evaluate(context);
+
+            // 2. check lvalue, rvalue
+            if (left_value != nullptr && right_value != nullptr) {
+
+                std::shared_ptr<Value> left_promoted = left_value->Promote(right_value);
+                std::shared_ptr<Value> right_promoted = right_value->Promote(left_value);
+
+                // 3. check promoted values
+                if (left_promoted != nullptr && right_promoted != nullptr) {
+
+                    result = left_promoted->OperateBinary(this->getType(),
+                                                          right_promoted);
+                }
+
+            }
+
+        }
 
         return result;
     }
@@ -71,6 +89,7 @@ namespace apus {
 
         std::shared_ptr<Value> result = nullptr;
         result = expression_->Evaluate(context);
+        result = result->OperateUnary(this->getType());
 
         return result;
     }

--- a/src/ast/value/float_value.cpp
+++ b/src/ast/value/float_value.cpp
@@ -1,0 +1,190 @@
+#include <cmath>
+#include <limits>
+
+#include "ast/value/float_value.h"
+#include "ast/value/signed_int_value.h"
+
+namespace apus {
+
+    std::shared_ptr<Value> FloatValue::Promote(
+            const std::shared_ptr<Value> another) const {
+
+        // case 1. Exactly same type
+        if (type_ == another->getType()) {
+            return this->Copy();
+        }
+
+        // case 2. Same class but size
+        std::shared_ptr<FloatValue> another_dynamic = nullptr;
+        if ( (another_dynamic = std::dynamic_pointer_cast<FloatValue>(another)) ) {
+
+            TypeSpecifier type = getType() > another_dynamic->getType()
+                                 ? getType()
+                                 : another_dynamic->getType();
+
+            return std::make_shared<FloatValue>(type, this->getValue());
+        }
+
+        // case 3. Different class
+        else {
+
+            // case 3.1 SignedIntValue
+            std::shared_ptr<SignedIntValue> another_siv = nullptr;
+            if( (another_siv = std::dynamic_pointer_cast<SignedIntValue>(another)) ) {
+
+                return this->Copy();
+            }
+
+        }
+
+        return nullptr;
+    }
+
+    std::shared_ptr<Value> FloatValue::OperateBinary(
+            const Expression::Type expression_type,
+            const std::shared_ptr<Value> &right_promoted) const {
+
+        std::shared_ptr<Value> result = nullptr;
+
+        // 'right' value MUST be same type with this's type;
+        if (right_promoted->getType() == this->getType()) {
+
+            double epsilon = std::numeric_limits<double>::epsilon();
+
+            std::shared_ptr<FloatValue> right_dynamic = std::dynamic_pointer_cast<FloatValue>(right_promoted);
+
+            double left_value = this->getFloatValue();
+            double right_value = right_dynamic->getFloatValue();
+
+            double result_value = 0;
+            TypeSpecifier type = this->getType();
+
+            switch (expression_type) {
+
+                case Expression::Type::EXP_OR :
+                    return nullptr;
+                case Expression::Type::EXP_AND :
+                    return nullptr;
+
+                case Expression::Type::EXP_EQL :
+                    result_value = this->NearlyEqual(right_value);
+                    break;
+                case Expression::Type::EXP_NEQ :
+                    result_value = !this->NearlyEqual(right_value);
+                    break;
+                case Expression::Type::EXP_LSS :
+                    result_value = left_value < right_value;
+                    break;
+                case Expression::Type::EXP_GTR :
+                    result_value = left_value > right_value;
+                    break;
+                case Expression::Type::EXP_LEQ :
+                    result_value = (left_value < right_value) || this->NearlyEqual(right_value);
+                    break;
+                case Expression::Type::EXP_GEQ :
+                    result_value = (left_value > right_value) || this->NearlyEqual(right_value);
+                    break;
+
+                case Expression::Type::EXP_LSHIFT :
+                case Expression::Type::EXP_LSASSIGN :
+                    return nullptr;
+                case Expression::Type::EXP_RSHIFT :
+                case Expression::Type::EXP_RSASSIGN :
+                    return nullptr;
+
+                case Expression::Type::EXP_ADD :
+                case Expression::Type::EXP_ADDASSIGN :
+                    result_value = left_value + right_value;
+                    break;
+                case Expression::Type::EXP_SUB :
+                case Expression::Type::EXP_SUBASSIGN :
+                    result_value = left_value - right_value;
+                    break;
+                case Expression::Type::EXP_MUL :
+                case Expression::Type::EXP_MULASSIGN :
+                    result_value = left_value * right_value;
+                    break;
+                case Expression::Type::EXP_DIV :
+                case Expression::Type::EXP_DIVASSIGN :
+                    result_value = left_value / right_value;
+                    break;
+                case Expression::Type::EXP_MOD :
+                case Expression::Type::EXP_MODASSIGN :
+                    result_value = fmod(left_value, right_value);
+                    break;
+                case Expression::Type::EXP_XOR :
+                case Expression::Type::EXP_XORASSIGN :
+                    return nullptr;
+
+                case Expression::Type::EXP_LOR :
+                    result_value = left_value || right_value;
+                    break;
+                case Expression::Type::EXP_LAND :
+                    result_value = left_value && right_value;
+                    break;
+
+                default:
+                    return nullptr;
+            }
+
+            result = std::make_shared<FloatValue>(type, result_value);
+        }
+
+        return result;
+    }
+
+    std::shared_ptr<Value> FloatValue::OperateUnary(
+            const Expression::Type expression_type) const {
+
+        std::shared_ptr<Value> result = nullptr;
+        double result_value = 0;
+
+        switch (expression_type) {
+            case Expression::Type::EXP_NOT :
+                result_value = !(this->getFloatValue());
+                break;
+            case Expression::Type::EXP_REVERSE :
+                // reverse operation not supported
+                return nullptr;
+            case Expression::Type::EXP_SUB :
+                result_value = -(this->getFloatValue());
+                break;
+            case Expression::Type::EXP_ADD :
+                result_value = +(this->getFloatValue());
+                break;
+
+            default:
+                return nullptr;
+        }
+
+        result = std::make_shared<FloatValue>(this->getType(), result_value);
+
+        return result;
+    }
+
+    double FloatValue::NearlyEqual(double another) const {
+
+        const double a = getFloatValue();
+        const double b = another;
+
+        const double absA = std::abs(a);
+        const double absB = std::abs(b);
+        const double diff = std::abs(a - b);
+
+        const double epsilon = std::numeric_limits<double>::epsilon();
+
+        if (a == b) {
+            // shortcut, handles infinities
+            return true;
+        }
+        else if (a == 0 || b == 0 || diff < std::numeric_limits<double>::min()) {
+            // a or b is zero or both are extremely close to it
+            // relative error is less meaningful here
+            return diff < (epsilon * std::numeric_limits<double>::min());
+        }
+        else { // use relative error
+            return diff / std::min((absA + absB), std::numeric_limits<double>::max()) < epsilon;
+        }
+    }
+
+}

--- a/src/ast/value/signed_int_value.cpp
+++ b/src/ast/value/signed_int_value.cpp
@@ -1,0 +1,170 @@
+#include "ast/value/signed_int_value.h"
+#include "ast/expression.h"
+#include "common/common.h"
+
+#include "ast/value/float_value.h"
+
+namespace apus {
+
+    std::shared_ptr<Value> SignedIntValue::Promote(
+            const std::shared_ptr<Value> another) const {
+
+        // PROMOTE THIS, NOT another
+
+        // case 1. Exactly same type
+        if (type_ == another->getType()) {
+            return this->Copy();
+        }
+
+        // case 2. Same class but size
+        std::shared_ptr<SignedIntValue> another_dynamic = nullptr;
+        if ( (another_dynamic = std::dynamic_pointer_cast<SignedIntValue>(another)) ) {
+
+            TypeSpecifier type = getType() > another_dynamic->getType()
+                       ? getType()
+                       : another_dynamic->getType();
+
+            return std::make_shared<SignedIntValue>(type, this->getValue());
+        }
+
+        // case 3. Different class
+        else {
+
+            // case 3.1 FloatValue
+            std::shared_ptr<FloatValue> another_fv = nullptr;
+            if( (another_fv = std::dynamic_pointer_cast<FloatValue>(another)) ) {
+
+                double value = static_cast<double>(this->getIntValue());
+                return std::make_shared<FloatValue>(F64, value);
+            }
+
+        }
+
+        return nullptr;
+    }
+
+    std::shared_ptr<Value> SignedIntValue::OperateBinary(
+            const Expression::Type expression_type,
+            const std::shared_ptr<Value> &right_promoted) const {
+
+        std::shared_ptr<Value> result = nullptr;
+
+        // 'right' value MUST be same type with this's type;
+        if (right_promoted->getType() == this->getType()) {
+
+            std::shared_ptr<SignedIntValue> right_dynamic = std::dynamic_pointer_cast<SignedIntValue>(right_promoted);
+
+            int64_t left_value = this->getIntValue();
+            int64_t right_value = right_dynamic->getIntValue();
+
+            int64_t result_value = 0;
+
+            switch (expression_type) {
+
+                case Expression::Type::EXP_OR :
+                    result_value = left_value | right_value;
+                    break;
+                case Expression::Type::EXP_AND :
+                    result_value = left_value & right_value;
+                    break;
+
+                case Expression::Type::EXP_EQL :
+                    result_value = left_value == right_value;
+                    break;
+                case Expression::Type::EXP_NEQ :
+                    result_value = left_value != right_value;
+                    break;
+                case Expression::Type::EXP_LSS :
+                    result_value = left_value < right_value;
+                    break;
+                case Expression::Type::EXP_GTR :
+                    result_value = left_value > right_value;
+                    break;
+                case Expression::Type::EXP_LEQ :
+                    result_value = left_value <= right_value;
+                    break;
+                case Expression::Type::EXP_GEQ :
+                    result_value = left_value >= right_value;
+                    break;
+
+                case Expression::Type::EXP_LSHIFT :
+                case Expression::Type::EXP_LSASSIGN :
+                    result_value = left_value << right_value;
+                    break;
+                case Expression::Type::EXP_RSHIFT :
+                case Expression::Type::EXP_RSASSIGN :
+                    result_value = left_value >> right_value;
+                    break;
+
+                case Expression::Type::EXP_ADD :
+                case Expression::Type::EXP_ADDASSIGN :
+                    result_value = left_value + right_value;
+                    break;
+                case Expression::Type::EXP_SUB :
+                case Expression::Type::EXP_SUBASSIGN :
+                    result_value = left_value - right_value;
+                    break;
+                case Expression::Type::EXP_MUL :
+                case Expression::Type::EXP_MULASSIGN :
+                    result_value = left_value * right_value;
+                    break;
+                case Expression::Type::EXP_DIV :
+                case Expression::Type::EXP_DIVASSIGN :
+                    result_value = left_value / right_value;
+                    break;
+                case Expression::Type::EXP_MOD :
+                case Expression::Type::EXP_MODASSIGN :
+                    result_value = left_value % right_value;
+                    break;
+                case Expression::Type::EXP_XOR :
+                case Expression::Type::EXP_XORASSIGN :
+                    result_value = left_value ^ right_value;
+                    break;
+
+                case Expression::Type::EXP_LOR :
+                    result_value = left_value || right_value;
+                    break;
+                case Expression::Type::EXP_LAND :
+                    result_value = left_value && right_value;
+                    break;
+
+                default:
+                    return nullptr;
+            }
+
+            result = std::make_shared<SignedIntValue>(this->getType(), result_value);
+        }
+
+        return result;
+    }
+
+    std::shared_ptr<Value> SignedIntValue::OperateUnary(
+            const Expression::Type expression_type) const {
+
+        std::shared_ptr<Value> result = nullptr;
+        int64_t result_value = 0;
+
+        switch (expression_type) {
+            case Expression::Type::EXP_NOT :
+                result_value = !(this->getIntValue());
+                break;
+            case Expression::Type::EXP_REVERSE :
+                result_value = ~(this->getIntValue());
+                break;
+            case Expression::Type::EXP_SUB :
+                result_value = -(this->getIntValue());
+                break;
+            case Expression::Type::EXP_ADD :
+                result_value = +(this->getIntValue());
+                break;
+
+                default:
+                    return nullptr;
+        }
+
+        result = std::make_shared<SignedIntValue>(this->getType(), result_value);
+
+        return result;
+    }
+
+}

--- a/test/ast/ast_test.cpp
+++ b/test/ast/ast_test.cpp
@@ -1,0 +1,183 @@
+#include <list>
+#include <memory>
+
+#include "gtest/gtest.h"
+
+#include "ast/expression.h"
+#include "ast/statement/statement.h"
+
+#include "ast/value/signed_int_value.h"
+#include "ast/value/float_value.h"
+
+#include "vm/context.h"
+
+using namespace apus;
+
+apus::Context ctx;
+
+TEST (ASTTest, Expression_nullptr) {
+
+    //  nullptr input
+    {
+        std::shared_ptr<Expression> left_expr = nullptr;
+        std::shared_ptr<Expression> right_expr = nullptr;
+        Expression *expr = nullptr;
+
+        expr = new BinaryExpression(Expression::EXP_ADD, left_expr,
+                                    right_expr);
+
+        EXPECT_EQ(nullptr, expr->Evaluate(ctx));
+    }
+}
+
+// add, sub, mul, div and modulo
+TEST (ASTTest, Expression_ASMD) {
+
+    // 1 + 2 == 3
+    {
+        std::shared_ptr<Value> left_value = std::make_shared<SignedIntValue>(S32, 1);
+        std::shared_ptr<Expression> left_expr = std::make_shared<ValueExpression>(left_value);
+
+        std::shared_ptr<Value> right_value = std::make_shared<SignedIntValue>(S32, 2);
+        std::shared_ptr<Expression> right_expr = std::make_shared<ValueExpression>(right_value);
+        std::shared_ptr<Expression> expr = std::make_shared<BinaryExpression>(Expression::EXP_ADD, left_expr, right_expr);
+
+        std::shared_ptr<SignedIntValue> result = std::dynamic_pointer_cast<SignedIntValue>(expr->Evaluate(ctx));
+
+        EXPECT_EQ(3, result->getIntValue());
+    }
+
+    // 1 + 2 * 3 == 7
+    {
+        std::shared_ptr<Expression> _1 = std::make_shared<ValueExpression>(std::make_shared<SignedIntValue>(S32, 1));
+        std::shared_ptr<Expression> _2 = std::make_shared<ValueExpression>(std::make_shared<SignedIntValue>(S32, 2));
+        std::shared_ptr<Expression> _3 = std::make_shared<ValueExpression>(std::make_shared<SignedIntValue>(S32, 3));
+
+        std::shared_ptr<Expression> mul_expr = std::make_shared<BinaryExpression>(Expression::EXP_MUL, _2, _3);
+        std::shared_ptr<Expression> add_expr = std::make_shared<BinaryExpression>(Expression::EXP_ADD, _1, mul_expr);
+
+        std::shared_ptr<SignedIntValue> result = std::dynamic_pointer_cast<SignedIntValue>(add_expr->Evaluate(ctx));
+
+        EXPECT_EQ(7, result->getIntValue());
+    }
+
+    // ( 1 + 2 * 3 ) % 5 == 2
+    {
+        std::shared_ptr<Expression> _1 = std::make_shared<ValueExpression>(std::make_shared<SignedIntValue>(S32, 1));
+        std::shared_ptr<Expression> _2 = std::make_shared<ValueExpression>(std::make_shared<SignedIntValue>(S32, 2));
+        std::shared_ptr<Expression> _3 = std::make_shared<ValueExpression>(std::make_shared<SignedIntValue>(S32, 3));
+        std::shared_ptr<Expression> _5 = std::make_shared<ValueExpression>(std::make_shared<SignedIntValue>(S32, 5));
+
+        std::shared_ptr<Expression> mul_expr = std::make_shared<BinaryExpression>(Expression::EXP_MUL, _2, _3);
+        std::shared_ptr<Expression> add_expr = std::make_shared<BinaryExpression>(Expression::EXP_ADD, _1, mul_expr);
+
+        std::shared_ptr<Expression> mod_expr = std::make_shared<BinaryExpression>(Expression::EXP_MOD, add_expr, _5);
+
+        std::shared_ptr<SignedIntValue> result = std::dynamic_pointer_cast<SignedIntValue>(mod_expr->Evaluate(ctx));
+
+        EXPECT_EQ(2, result->getIntValue());
+    }
+
+    // 2 * 3.5 / 3
+    {
+        std::shared_ptr<Expression> _2 = std::make_shared<ValueExpression>(std::make_shared<SignedIntValue>(S64, 2));
+        std::shared_ptr<Expression> _3_5 = std::make_shared<ValueExpression>(std::make_shared<FloatValue>(F64, 3.5));
+        std::shared_ptr<Expression> _3 = std::make_shared<ValueExpression>(std::make_shared<SignedIntValue>(S64, 3));
+
+        std::shared_ptr<Expression> mul_expr = std::make_shared<BinaryExpression>(Expression::EXP_MUL, _2, _3_5);
+        std::shared_ptr<Expression> div_expr = std::make_shared<BinaryExpression>(Expression::EXP_DIV, mul_expr, _3);
+
+        std::shared_ptr<FloatValue> result = std::dynamic_pointer_cast<FloatValue>(div_expr->Evaluate(ctx));
+
+        EXPECT_EQ( (2 * 3.5 / 3) , result->getFloatValue());
+    }
+
+}
+
+TEST (ASTTest, Expression_Int_Compare) {
+
+    {
+        std::shared_ptr<Expression> _2 = std::make_shared<ValueExpression>(std::make_shared<SignedIntValue>(S32, 2));
+        std::shared_ptr<Expression> _3 = std::make_shared<ValueExpression>(std::make_shared<SignedIntValue>(S32, 3));
+
+        std::shared_ptr<Expression> eql_expr = std::make_shared<BinaryExpression>(Expression::EXP_EQL, _2, _3);
+        std::shared_ptr<Expression> neq_expr = std::make_shared<BinaryExpression>(Expression::EXP_NEQ, _2, _3);
+        std::shared_ptr<Expression> lss_expr = std::make_shared<BinaryExpression>(Expression::EXP_LSS, _2, _3);
+        std::shared_ptr<Expression> gtr_expr = std::make_shared<BinaryExpression>(Expression::EXP_GTR, _2, _3);
+        std::shared_ptr<Expression> leq_expr = std::make_shared<BinaryExpression>(Expression::EXP_LEQ, _2, _3);
+        std::shared_ptr<Expression> geq_expr = std::make_shared<BinaryExpression>(Expression::EXP_GEQ, _2, _3);
+
+        std::shared_ptr<SignedIntValue> result = std::dynamic_pointer_cast<SignedIntValue>(eql_expr->Evaluate(ctx));
+        EXPECT_EQ( 2 == 3, result->getIntValue());
+        result = std::dynamic_pointer_cast<SignedIntValue>(neq_expr->Evaluate(ctx));
+        EXPECT_EQ( 2 != 3, result->getIntValue());
+        result = std::dynamic_pointer_cast<SignedIntValue>(lss_expr->Evaluate(ctx));
+        EXPECT_EQ( 2 < 3, result->getIntValue());
+        result = std::dynamic_pointer_cast<SignedIntValue>(gtr_expr->Evaluate(ctx));
+        EXPECT_EQ( 2 > 3, result->getIntValue());
+        result = std::dynamic_pointer_cast<SignedIntValue>(leq_expr->Evaluate(ctx));
+        EXPECT_EQ( 2 <= 3, result->getIntValue());
+        result = std::dynamic_pointer_cast<SignedIntValue>(geq_expr->Evaluate(ctx));
+        EXPECT_EQ( 2 >= 3, result->getIntValue());
+
+    }
+}
+
+TEST (ASTTest, Expression_Float_Compare) {
+
+    const double __2_5 = 2.000000000005;
+    const double __2_7 = 2.000000000007;
+
+    {
+        std::shared_ptr<Expression> _2_5 = std::make_shared<ValueExpression>(std::make_shared<FloatValue>(F32, __2_5));
+        std::shared_ptr<Expression> _2_7 = std::make_shared<ValueExpression>(std::make_shared<FloatValue>(F32, __2_7));
+
+        std::shared_ptr<Expression> eql_expr = std::make_shared<BinaryExpression>(Expression::EXP_EQL, _2_5, _2_7);
+        std::shared_ptr<Expression> neq_expr = std::make_shared<BinaryExpression>(Expression::EXP_NEQ, _2_5, _2_7);
+        std::shared_ptr<Expression> lss_expr = std::make_shared<BinaryExpression>(Expression::EXP_LSS, _2_5, _2_7);
+        std::shared_ptr<Expression> gtr_expr = std::make_shared<BinaryExpression>(Expression::EXP_GTR, _2_5, _2_7);
+        std::shared_ptr<Expression> leq_expr = std::make_shared<BinaryExpression>(Expression::EXP_LEQ, _2_5, _2_7);
+        std::shared_ptr<Expression> geq_expr = std::make_shared<BinaryExpression>(Expression::EXP_GEQ, _2_5, _2_7);
+
+        std::shared_ptr<FloatValue> result = std::dynamic_pointer_cast<FloatValue>(eql_expr->Evaluate(ctx));
+        EXPECT_EQ( false, result->getFloatValue());
+        result = std::dynamic_pointer_cast<FloatValue>(neq_expr->Evaluate(ctx));
+        EXPECT_EQ( true, result->getFloatValue());
+        result = std::dynamic_pointer_cast<FloatValue>(lss_expr->Evaluate(ctx));
+        EXPECT_EQ( true, result->getFloatValue());
+        result = std::dynamic_pointer_cast<FloatValue>(gtr_expr->Evaluate(ctx));
+        EXPECT_EQ( false, result->getFloatValue());
+        result = std::dynamic_pointer_cast<FloatValue>(leq_expr->Evaluate(ctx));
+        EXPECT_EQ( true, result->getFloatValue());
+        result = std::dynamic_pointer_cast<FloatValue>(geq_expr->Evaluate(ctx));
+        EXPECT_EQ( false, result->getFloatValue());
+
+    }
+}
+
+TEST (ASTTest, Expression_Float_EQL_Compare) {
+
+    const double a = 0.15 + 0.15;
+    const double b = 0.1 + 0.2;
+
+    std::shared_ptr<Expression> a_ = std::make_shared<ValueExpression>(std::make_shared<FloatValue>(F64, a));
+    std::shared_ptr<Expression> b_ = std::make_shared<ValueExpression>(std::make_shared<FloatValue>(F64, b));
+
+    std::shared_ptr<Expression> eql_expr = std::make_shared<BinaryExpression>(Expression::EXP_EQL, a_, b_);
+    std::shared_ptr<Expression> neq_expr = std::make_shared<BinaryExpression>(Expression::EXP_NEQ, a_, b_);
+    std::shared_ptr<Expression> leq_expr = std::make_shared<BinaryExpression>(Expression::EXP_LEQ, a_, b_);
+
+    // a == b
+    std::shared_ptr<FloatValue> result = std::dynamic_pointer_cast<FloatValue>(eql_expr->Evaluate(ctx));
+    EXPECT_EQ( true, result->getFloatValue());
+
+    // a != b
+    result = std::dynamic_pointer_cast<FloatValue>(neq_expr->Evaluate(ctx));
+    EXPECT_EQ( false, result->getFloatValue());
+
+    // a <= b
+    result = std::dynamic_pointer_cast<FloatValue>(leq_expr->Evaluate(ctx));
+    EXPECT_EQ( true, result->getFloatValue());
+
+}
+


### PR DESCRIPTION
Value클래스를 상속받은 파생클래스들을 만들었습니다. 각 타입마다 클래스를 하나씩 파생시켰습니다. 이들은 yacc에서 지정한 rule과 매치되면 실행하는 action부분에서 트리구조로 생성될 것입니다.

현재까지 구현된 SignedIntValue와 FloatValue 만 추가했습니다. 다른 클래스들은 구현되는대로 추가하겠습니다.

SignedIntValue와 FloatIntValue에 대한 테스트 코드를 추가했습니다.

FloatValue의 동등비교에서 epsilon을 이용한 비교를 합니다.
