### PR TITLE
VM: Fixed ctor of UnaryExpression and IfStatement

### DIFF
--- a/include/ast/expression.h
+++ b/include/ast/expression.h
@@ -92,9 +92,9 @@ namespace apus {
 
     class UnaryExpression : public Expression {
     public:
-        UnaryExpression(std::shared_ptr<Expression> expression);
+        UnaryExpression(Type type, std::shared_ptr<Expression> expression);
 
-        UnaryExpression(Expression* expression);
+        UnaryExpression(Type type, Expression* expression);
 
         virtual ~UnaryExpression();
 

--- a/include/ast/statement/for_statement.h
+++ b/include/ast/statement/for_statement.h
@@ -16,12 +16,12 @@ namespace apus {
         ForStatement (std::shared_ptr<Expression> initialization,
                       std::shared_ptr<Expression> termination,
                       std::shared_ptr<Expression> increment,
-                      std::shared_ptr<Block> body_statement);
+                      std::shared_ptr<Statement> body_statement);
 
         ForStatement (Expression* initialization,
                       Expression* termination,
                       Expression* increment,
-                      Block* body);
+                      Statement* body);
 
         virtual ~ForStatement ();
 
@@ -33,7 +33,7 @@ namespace apus {
         std::shared_ptr<Expression> termination_;
         std::shared_ptr<Expression> increment_;
 
-        std::shared_ptr<Block>  body_;
+        std::shared_ptr<Statement>  body_;
     };
 }
 

--- a/include/ast/statement/if_statement.h
+++ b/include/ast/statement/if_statement.h
@@ -12,12 +12,12 @@ namespace apus {
     class IfStatement : public Statement {
     public:
         IfStatement(std::shared_ptr<Expression> condition,
-                    std::shared_ptr<Block> true_block,
+                    std::shared_ptr<Statement> true_block,
                     std::shared_ptr<Statement> false_block);
 
         IfStatement(Expression* condition,
-                    Block* true_block,
-                    Block* false_block);
+                    Statement* true_block,
+                    Statement* false_block);
 
         virtual ~IfStatement();
 
@@ -26,7 +26,7 @@ namespace apus {
     private:
         std::shared_ptr<Expression> condition_;
 
-        std::shared_ptr<Block> true_block_;
+        std::shared_ptr<Statement> true_block_;
         std::shared_ptr<Statement> false_block_;
     };
 

--- a/src/ast/expression.cpp
+++ b/src/ast/expression.cpp
@@ -50,16 +50,15 @@ namespace apus {
 
     // UnaryExpression::
 
-    UnaryExpression::UnaryExpression(std::shared_ptr<Expression> expression)
-        : Expression(EXP_UNARY), expression_(expression) {
+    UnaryExpression::UnaryExpression(Type type, std::shared_ptr<Expression> expression)
+        : Expression(type), expression_(expression) {
 
     }
 
-    UnaryExpression::UnaryExpression(Expression* expression)
-        : Expression(EXP_UNARY), expression_(expression) {
+    UnaryExpression::UnaryExpression(Type type, Expression* expression) {
 
         std::shared_ptr<Expression> shared_expr(expression);
-        expression_ = shared_expr;
+        UnaryExpression(type, shared_expr);
 
     }
 

--- a/src/ast/statement/for_statement.cpp
+++ b/src/ast/statement/for_statement.cpp
@@ -7,7 +7,7 @@ namespace apus {
     ForStatement::ForStatement(std::shared_ptr<Expression> initialization,
                                std::shared_ptr<Expression> termination,
                                std::shared_ptr<Expression> increment,
-                               std::shared_ptr<Block> body)
+                               std::shared_ptr<Statement> body)
 
         : initialization_(initialization), termination_(termination),
           increment_(increment), body_(body) {
@@ -16,12 +16,12 @@ namespace apus {
     ForStatement::ForStatement(Expression* initialization,
                                Expression* termination,
                                Expression* increment,
-                               Block* body) {
+                               Statement* body) {
 
         initialization_ = std::shared_ptr<Expression>(initialization);
         termination_ = std::shared_ptr<Expression>(termination);
         increment_ = std::shared_ptr<Expression>(increment);
-        body_ = std::shared_ptr<Block>(body);
+        body_ = std::shared_ptr<Statement>(body);
     }
 
     ForStatement::~ForStatement() {

--- a/src/ast/statement/if_statement.cpp
+++ b/src/ast/statement/if_statement.cpp
@@ -6,17 +6,17 @@
 namespace apus {
 
     IfStatement::IfStatement(std::shared_ptr<Expression> condition,
-                             std::shared_ptr<Block> true_block,
+                             std::shared_ptr<Statement> true_block,
                              std::shared_ptr<Statement> false_block)
         : condition_(condition), true_block_(true_block),
           false_block_(false_block) {
     }
 
     IfStatement::IfStatement(Expression *condition,
-                             Block *true_block,
-                             Block *false_block) {
+                             Statement *true_block,
+                             Statement *false_block) {
         condition_ = std::shared_ptr<Expression>(condition);
-        true_block_ = std::shared_ptr<Block>(true_block);
+        true_block_ = std::shared_ptr<Statement>(true_block);
         false_block_ = std::shared_ptr<Statement>(false_block);
     }
 


### PR DESCRIPTION
UnaryExpression에서 Expression::Type을 받지 않는 문제, IfStatement에서 여전히 세번째 인자(false_block)를 'Block*'으로 받고 있었던 문제를 해결했습니다.
- ForStatement의 마지막 인자를 Statement*로 받게 수정했습니다.
