### PR TITLE
VM: Value: Added derived classes of 'Value' -v6

### DIFF
--- a/include/ast/expression.h
+++ b/include/ast/expression.h
@@ -132,9 +132,9 @@ namespace apus {
 
     class AssignExpression : public Expression {
     public:
-        AssignExpression(std::string name,
+        AssignExpression(Type type, std::string name,
                          std::shared_ptr<Expression> expression);
-        AssignExpression(char* name, Expression* expression);
+        AssignExpression(Type type, char* name, Expression* expression);
         virtual ~AssignExpression();
 
         virtual std::shared_ptr<Value> Evaluate(Context& context);

--- a/include/ast/value/float_value.h
+++ b/include/ast/value/float_value.h
@@ -1,0 +1,50 @@
+#ifndef FLOAT_VALUE_H_
+#define FLOAT_VALUE_H_
+
+#include <memory>
+#include "value.h"
+#include "common/common.h"
+
+namespace apus {
+
+    class FloatValue : public Value {
+    public:
+
+        static std::shared_ptr<FloatValue> Create(TypeSpecifier type, double value);
+
+        virtual ~FloatValue() {}
+
+        virtual std::shared_ptr<Value> Copy() const {
+            return FloatValue::Create(type_, getFloatValue());
+        }
+        virtual std::shared_ptr<Value> Promote(
+                const std::shared_ptr<Value> another) const override;
+
+        virtual std::shared_ptr<Value> OperateBinary(
+                const Expression::Type expression_type,
+                const std::shared_ptr<Value>& right) const override;
+
+        virtual std::shared_ptr<Value> OperateUnary(
+                const Expression::Type expression_type) const override;
+
+        double getFloatValue() const {
+            return *((double *)value_.get());
+        }
+
+    protected:
+
+        double NearlyEqual(double another) const;
+
+        FloatValue(TypeSpecifier type, double value)
+                : Value(type, std::make_shared<double>(value)) {
+        }
+
+        FloatValue(TypeSpecifier type, std::shared_ptr<void> value_ptr)
+                : Value(type, value_ptr) {
+        }
+
+    };
+
+}
+
+#endif

--- a/include/ast/value/signed_int_value.h
+++ b/include/ast/value/signed_int_value.h
@@ -1,0 +1,49 @@
+#ifndef SIGNED_INT_VALUE_H_
+#define SIGNED_INT_VALUE_H_
+
+#include <memory>
+#include "value.h"
+#include "common/common.h"
+
+namespace apus {
+
+    class SignedIntValue : public Value {
+    public:
+
+        static std::shared_ptr<SignedIntValue> Create(TypeSpecifier type, int64_t value);
+
+        virtual ~SignedIntValue() {}
+
+        virtual std::shared_ptr<Value> Copy() const override {
+            return SignedIntValue::Create(type_, getIntValue());
+        }
+
+        virtual std::shared_ptr<Value> Promote(
+                const std::shared_ptr<Value> another) const override;
+
+        virtual std::shared_ptr<Value> OperateBinary(
+                const Expression::Type expression_type,
+                const std::shared_ptr<Value>& right) const override;
+
+        virtual std::shared_ptr<Value> OperateUnary(
+                const Expression::Type expression_type) const override;
+
+        inline int64_t getIntValue() const {
+            return *((int64_t *)value_.get());
+        }
+
+    protected:
+
+        SignedIntValue(TypeSpecifier type, int64_t value)
+                : Value(type, std::make_shared<int64_t>(value)) {
+        }
+
+        SignedIntValue(TypeSpecifier type, std::shared_ptr<void> value_ptr)
+                : Value(type, value_ptr) {
+        }
+
+    };
+
+}
+
+#endif

--- a/include/ast/value/value.h
+++ b/include/ast/value/value.h
@@ -12,26 +12,35 @@ namespace apus {
     class Value {
     public:
 
-        Value(TypeSpecifier type) : type_(type) {}
         virtual ~Value(){}
 
-        // returns type of current object
         virtual TypeSpecifier getType() const { return type_; };
+
+        virtual std::shared_ptr<void> getValue() const { return value_; }
+
+        int getSize() const { return TypeLength(type_); }
 
         // Deep Copy function
         inline virtual std::shared_ptr<Value> Copy() const { return nullptr; }
 
-        int getSize() const { return TypeLength(type_); }
+        virtual std::shared_ptr<Value> Promote(
+                const std::shared_ptr<Value> another) const = 0;
 
-        virtual std::shared_ptr<Value> Promote(const Value& another) const = 0;
-
-        virtual std::shared_ptr<Value> Operate(
+        virtual std::shared_ptr<Value> OperateBinary(
                 const Expression::Type expression_type,
-                const std::shared_ptr<Value>& right) const { return nullptr; }
+                const std::shared_ptr<Value>& right) const = 0;
+
+        virtual std::shared_ptr<Value> OperateUnary(
+                const Expression::Type expression_type) const = 0;
 
     protected:
 
-        TypeSpecifier type_;
+        Value(TypeSpecifier type, std::shared_ptr<void> value)
+                : type_(type), value_(value) {}
+
+        TypeSpecifier           type_;
+        std::shared_ptr<void>   value_;
+
     };
 
 }

--- a/src/ast/expression.cpp
+++ b/src/ast/expression.cpp
@@ -132,14 +132,16 @@ namespace apus {
 
     // AssignExpression::
 
-    AssignExpression::AssignExpression(std::string name,
+    AssignExpression::AssignExpression(Type type,
+                                       std::string name,
                                        std::shared_ptr<Expression> expression)
-        : Expression(EXP_ASSIGN), name_(name), expression_(expression) {
+        : Expression(type), name_(name), expression_(expression) {
 
     }
 
-    AssignExpression::AssignExpression(char* name, Expression* expression) {
-        AssignExpression(std::string(name), std::shared_ptr<Expression>(expression));
+    AssignExpression::AssignExpression(Type type, char* name,
+                                       Expression* expression) {
+        AssignExpression(type, std::string(name), std::shared_ptr<Expression>(expression));
     }
 
     AssignExpression::~AssignExpression() {
@@ -148,9 +150,28 @@ namespace apus {
 
     std::shared_ptr<Value> AssignExpression::Evaluate(Context &context) {
 
-        std::shared_ptr<Value> result = nullptr;
+        if (expression_ != nullptr) {
 
-        return result;
+            // Find left value from the variable table
+            std::shared_ptr<Value> left = nullptr;
+            std::shared_ptr<Value> right = expression_->Evaluate(context);
+
+            if (left != nullptr && right != nullptr) {
+
+                std::shared_ptr<Value> right_promoted = right->Promote(left);
+
+                if (right_promoted != nullptr) {
+
+                    std::shared_ptr<Value> result =
+                            left->OperateBinary(this->getType(), right_promoted);
+
+                    // and, put 'result' value into the variable
+
+                }
+            }
+            return left;
+        }
+        return nullptr;
     }
 
     // MemberExpression::

--- a/src/ast/expression.cpp
+++ b/src/ast/expression.cpp
@@ -40,10 +40,28 @@ namespace apus {
 
         std::shared_ptr<Value> result = nullptr;
 
-        std::shared_ptr<Value> lValue = left_expression_->Evaluate(context);
-        std::shared_ptr<Value> rValue = right_expression_->Evaluate(context);
+        // 1. check expression
+        if (left_expression_ != nullptr && right_expression_ != nullptr) {
 
-        result = lValue->Operate(this->getType(), rValue);
+            std::shared_ptr<Value> left_value = left_expression_->Evaluate(context);
+            std::shared_ptr<Value> right_value = right_expression_->Evaluate(context);
+
+            // 2. check lvalue, rvalue
+            if (left_value != nullptr && right_value != nullptr) {
+
+                std::shared_ptr<Value> left_promoted = left_value->Promote(right_value);
+                std::shared_ptr<Value> right_promoted = right_value->Promote(left_value);
+
+                // 3. check promoted values
+                if (left_promoted != nullptr && right_promoted != nullptr) {
+
+                    result = left_promoted->OperateBinary(this->getType(),
+                                                          right_promoted);
+                }
+
+            }
+
+        }
 
         return result;
     }
@@ -70,6 +88,7 @@ namespace apus {
 
         std::shared_ptr<Value> result = nullptr;
         result = expression_->Evaluate(context);
+        result = result->OperateUnary(this->getType());
 
         return result;
     }

--- a/src/ast/value/float_value.cpp
+++ b/src/ast/value/float_value.cpp
@@ -1,0 +1,205 @@
+#include <cmath>
+#include <limits>
+
+#include "ast/value/float_value.h"
+#include "ast/value/signed_int_value.h"
+
+namespace apus {
+
+    std::shared_ptr<FloatValue> FloatValue::Create(TypeSpecifier type,
+                                                   double value) {
+        // check 'type'
+        if (type == F32 || type == F64) {
+            return std::shared_ptr<FloatValue>(new FloatValue(type, value));
+        }
+
+        return nullptr;
+    }
+
+    std::shared_ptr<Value> FloatValue::Promote(
+            const std::shared_ptr<Value> another) const {
+
+        const TypeSpecifier another_type = another->getType();
+
+        // case 1. Exactly same type
+        if (type_ == another_type) {
+            return this->Copy();
+        }
+
+        switch (another_type) {
+
+            // case 2. Same class but size
+            case F32:
+            case F64: {
+                TypeSpecifier type = getType() > another_type
+                                     ? getType()
+                                     : another_type;
+
+                return FloatValue::Create(type, this->getFloatValue());
+            }
+
+            // case 3. Different class
+            case S8:
+            case S16:
+            case S32:
+            case S64: {
+                
+                // case 3.1 SignedIntValue
+                return this->Copy();
+
+            }
+            default:
+                return nullptr;
+        }
+
+        return nullptr;
+    }
+
+    std::shared_ptr<Value> FloatValue::OperateBinary(
+            const Expression::Type expression_type,
+            const std::shared_ptr<Value> &right_promoted) const {
+
+        std::shared_ptr<Value> result = nullptr;
+
+        // 'right' value MUST be same type with this's type;
+        if (right_promoted->getType() == this->getType()) {
+
+            double epsilon = std::numeric_limits<double>::epsilon();
+
+            std::shared_ptr<FloatValue> right_dynamic = std::dynamic_pointer_cast<FloatValue>(right_promoted);
+
+            double left_value = this->getFloatValue();
+            double right_value = right_dynamic->getFloatValue();
+
+            double result_value = 0;
+            TypeSpecifier type = this->getType();
+
+            switch (expression_type) {
+
+                case Expression::Type::EXP_OR :
+                    return nullptr;
+                case Expression::Type::EXP_AND :
+                    return nullptr;
+
+                case Expression::Type::EXP_EQL :
+                    result_value = this->NearlyEqual(right_value);
+                    break;
+                case Expression::Type::EXP_NEQ :
+                    result_value = !this->NearlyEqual(right_value);
+                    break;
+                case Expression::Type::EXP_LSS :
+                    result_value = left_value < right_value;
+                    break;
+                case Expression::Type::EXP_GTR :
+                    result_value = left_value > right_value;
+                    break;
+                case Expression::Type::EXP_LEQ :
+                    result_value = (left_value < right_value) || this->NearlyEqual(right_value);
+                    break;
+                case Expression::Type::EXP_GEQ :
+                    result_value = (left_value > right_value) || this->NearlyEqual(right_value);
+                    break;
+
+                case Expression::Type::EXP_LSHIFT :
+                case Expression::Type::EXP_LSASSIGN :
+                    return nullptr;
+                case Expression::Type::EXP_RSHIFT :
+                case Expression::Type::EXP_RSASSIGN :
+                    return nullptr;
+
+                case Expression::Type::EXP_ADD :
+                case Expression::Type::EXP_ADDASSIGN :
+                    result_value = left_value + right_value;
+                    break;
+                case Expression::Type::EXP_SUB :
+                case Expression::Type::EXP_SUBASSIGN :
+                    result_value = left_value - right_value;
+                    break;
+                case Expression::Type::EXP_MUL :
+                case Expression::Type::EXP_MULASSIGN :
+                    result_value = left_value * right_value;
+                    break;
+                case Expression::Type::EXP_DIV :
+                case Expression::Type::EXP_DIVASSIGN :
+                    result_value = left_value / right_value;
+                    break;
+                case Expression::Type::EXP_MOD :
+                case Expression::Type::EXP_MODASSIGN :
+                    result_value = fmod(left_value, right_value);
+                    break;
+                case Expression::Type::EXP_XOR :
+                case Expression::Type::EXP_XORASSIGN :
+                    return nullptr;
+
+                case Expression::Type::EXP_LOR :
+                    result_value = left_value || right_value;
+                    break;
+                case Expression::Type::EXP_LAND :
+                    result_value = left_value && right_value;
+                    break;
+
+                default:
+                    return nullptr;
+            }
+
+            result = FloatValue::Create(type, result_value);
+        }
+
+        return result;
+    }
+
+    std::shared_ptr<Value> FloatValue::OperateUnary(
+            const Expression::Type expression_type) const {
+
+        std::shared_ptr<Value> result = nullptr;
+        double result_value = 0;
+
+        switch (expression_type) {
+            case Expression::Type::EXP_NOT :
+                result_value = !(this->getFloatValue());
+                break;
+            case Expression::Type::EXP_REVERSE :
+                // reverse operation not supported
+                return nullptr;
+            case Expression::Type::EXP_SUB :
+                result_value = -(this->getFloatValue());
+                break;
+            case Expression::Type::EXP_ADD :
+                result_value = +(this->getFloatValue());
+                break;
+
+            default:
+                return nullptr;
+        }
+
+        result = FloatValue::Create(this->getType(), result_value);
+
+        return result;
+    }
+
+    double FloatValue::NearlyEqual(double another) const {
+
+        const double a = getFloatValue();
+        const double b = another;
+
+        const double absA = std::abs(a);
+        const double absB = std::abs(b);
+        const double diff = std::abs(a - b);
+
+        const double epsilon = std::numeric_limits<double>::epsilon();
+
+        if (a == b) {
+            // shortcut, handles infinities
+            return true;
+        }
+        else if (a == 0 || b == 0 || diff < std::numeric_limits<double>::min()) {
+            // a or b is zero or both are extremely close to it
+            // relative error is less meaningful here
+            return diff < (epsilon * std::numeric_limits<double>::min());
+        }
+        else { // use relative error
+            return diff / std::min((absA + absB), std::numeric_limits<double>::max()) < epsilon;
+        }
+    }
+
+}

--- a/src/ast/value/signed_int_value.cpp
+++ b/src/ast/value/signed_int_value.cpp
@@ -1,0 +1,188 @@
+#include "ast/value/signed_int_value.h"
+#include "ast/expression.h"
+#include "common/common.h"
+
+#include "ast/value/float_value.h"
+
+namespace apus {
+
+    std::shared_ptr<SignedIntValue> SignedIntValue::Create(
+            TypeSpecifier type, int64_t value) {
+
+        // check 'type'
+        if (type == S8 || type == S16 || type == S32 || type == S64) {
+            return std::shared_ptr<SignedIntValue>(new SignedIntValue(type, value));
+        }
+
+        return nullptr;
+    }
+
+    std::shared_ptr<Value> SignedIntValue::Promote(
+            const std::shared_ptr<Value> another) const {
+
+        // PROMOTE THIS, NOT another
+
+        const TypeSpecifier another_type = another->getType();
+
+        // case 1. Exactly same type
+        if (type_ == another_type) {
+            return this->Copy();
+        }
+
+        switch (another_type) {
+
+            // case 2. Same class but size
+            case S8:
+            case S16:
+            case S32:
+            case S64: {
+
+                TypeSpecifier return_type = getType() > another_type
+                                            ? getType()
+                                            : another_type;
+
+                return SignedIntValue::Create(return_type, this->getIntValue());
+            }
+
+            // case 3. Different class
+            case F32:
+            case F64: {
+
+                double double_value = static_cast<double>(this->getIntValue());
+                return FloatValue::Create(F64, double_value);
+
+                break;
+            }
+
+            default:
+                return nullptr;
+        }
+
+        return nullptr;
+    }
+
+    std::shared_ptr<Value> SignedIntValue::OperateBinary(
+            const Expression::Type expression_type,
+            const std::shared_ptr<Value> &right_promoted) const {
+
+        std::shared_ptr<Value> result = nullptr;
+
+        // 'right' value MUST be same type with this's type;
+        if (right_promoted->getType() == this->getType()) {
+
+            std::shared_ptr<SignedIntValue> right_dynamic = std::dynamic_pointer_cast<SignedIntValue>(right_promoted);
+
+            int64_t left_value = this->getIntValue();
+            int64_t right_value = right_dynamic->getIntValue();
+
+            int64_t result_value = 0;
+
+            switch (expression_type) {
+
+                case Expression::Type::EXP_OR :
+                    result_value = left_value | right_value;
+                    break;
+                case Expression::Type::EXP_AND :
+                    result_value = left_value & right_value;
+                    break;
+
+                case Expression::Type::EXP_EQL :
+                    result_value = left_value == right_value;
+                    break;
+                case Expression::Type::EXP_NEQ :
+                    result_value = left_value != right_value;
+                    break;
+                case Expression::Type::EXP_LSS :
+                    result_value = left_value < right_value;
+                    break;
+                case Expression::Type::EXP_GTR :
+                    result_value = left_value > right_value;
+                    break;
+                case Expression::Type::EXP_LEQ :
+                    result_value = left_value <= right_value;
+                    break;
+                case Expression::Type::EXP_GEQ :
+                    result_value = left_value >= right_value;
+                    break;
+
+                case Expression::Type::EXP_LSHIFT :
+                case Expression::Type::EXP_LSASSIGN :
+                    result_value = left_value << right_value;
+                    break;
+                case Expression::Type::EXP_RSHIFT :
+                case Expression::Type::EXP_RSASSIGN :
+                    result_value = left_value >> right_value;
+                    break;
+
+                case Expression::Type::EXP_ADD :
+                case Expression::Type::EXP_ADDASSIGN :
+                    result_value = left_value + right_value;
+                    break;
+                case Expression::Type::EXP_SUB :
+                case Expression::Type::EXP_SUBASSIGN :
+                    result_value = left_value - right_value;
+                    break;
+                case Expression::Type::EXP_MUL :
+                case Expression::Type::EXP_MULASSIGN :
+                    result_value = left_value * right_value;
+                    break;
+                case Expression::Type::EXP_DIV :
+                case Expression::Type::EXP_DIVASSIGN :
+                    result_value = left_value / right_value;
+                    break;
+                case Expression::Type::EXP_MOD :
+                case Expression::Type::EXP_MODASSIGN :
+                    result_value = left_value % right_value;
+                    break;
+                case Expression::Type::EXP_XOR :
+                case Expression::Type::EXP_XORASSIGN :
+                    result_value = left_value ^ right_value;
+                    break;
+
+                case Expression::Type::EXP_LOR :
+                    result_value = left_value || right_value;
+                    break;
+                case Expression::Type::EXP_LAND :
+                    result_value = left_value && right_value;
+                    break;
+
+                default:
+                    return nullptr;
+            }
+
+            result = SignedIntValue::Create(this->getType(), result_value);
+        }
+
+        return result;
+    }
+
+    std::shared_ptr<Value> SignedIntValue::OperateUnary(
+            const Expression::Type expression_type) const {
+
+        std::shared_ptr<Value> result = nullptr;
+        int64_t result_value = 0;
+
+        switch (expression_type) {
+            case Expression::Type::EXP_NOT :
+                result_value = !(this->getIntValue());
+                break;
+            case Expression::Type::EXP_REVERSE :
+                result_value = ~(this->getIntValue());
+                break;
+            case Expression::Type::EXP_SUB :
+                result_value = -(this->getIntValue());
+                break;
+            case Expression::Type::EXP_ADD :
+                result_value = +(this->getIntValue());
+                break;
+
+                default:
+                    return nullptr;
+        }
+
+        result = SignedIntValue::Create(this->getType(), result_value);
+
+        return result;
+    }
+
+}

--- a/test/ast/ast_test.cpp
+++ b/test/ast/ast_test.cpp
@@ -1,0 +1,182 @@
+#include <list>
+#include <memory>
+
+#include "gtest/gtest.h"
+
+#include "ast/expression.h"
+#include "ast/statement/statement.h"
+
+#include "ast/value/signed_int_value.h"
+#include "ast/value/float_value.h"
+
+#include "vm/context.h"
+
+using namespace apus;
+
+apus::Context ctx;
+
+TEST (ASTTest, Expression_nullptr) {
+
+    //  nullptr input
+    {
+        std::shared_ptr<Expression> left_expr = nullptr;
+        std::shared_ptr<Expression> right_expr = nullptr;
+        Expression *expr = nullptr;
+
+        expr = new BinaryExpression(Expression::EXP_ADD, left_expr,
+                                    right_expr);
+
+        EXPECT_EQ(nullptr, expr->Evaluate(ctx));
+    }
+}
+
+// add, sub, mul, div and modulo
+TEST (ASTTest, Expression_ASMD) {
+
+    // 1 + 2 == 3
+    {
+        std::shared_ptr<Value> left_value = SignedIntValue::Create(S32, 1);
+        std::shared_ptr<Expression> left_expr = std::make_shared<ValueExpression>(left_value);
+
+        std::shared_ptr<Value> right_value = SignedIntValue::Create(S32, 2);
+        std::shared_ptr<Expression> right_expr = std::make_shared<ValueExpression>(right_value);
+        std::shared_ptr<Expression> expr = std::make_shared<BinaryExpression>(Expression::EXP_ADD, left_expr, right_expr);
+
+        std::shared_ptr<SignedIntValue> result = std::dynamic_pointer_cast<SignedIntValue>(expr->Evaluate(ctx));
+
+        EXPECT_EQ(3, result->getIntValue());
+    }
+
+    // 1 + 2 * 3 == 7
+    {
+        std::shared_ptr<Expression> _1 = std::make_shared<ValueExpression>(SignedIntValue::Create(S32, 1));
+        std::shared_ptr<Expression> _2 = std::make_shared<ValueExpression>(SignedIntValue::Create(S32, 2));
+        std::shared_ptr<Expression> _3 = std::make_shared<ValueExpression>(SignedIntValue::Create(S32, 3));
+
+        std::shared_ptr<Expression> mul_expr = std::make_shared<BinaryExpression>(Expression::EXP_MUL, _2, _3);
+        std::shared_ptr<Expression> add_expr = std::make_shared<BinaryExpression>(Expression::EXP_ADD, _1, mul_expr);
+
+        std::shared_ptr<SignedIntValue> result = std::dynamic_pointer_cast<SignedIntValue>(add_expr->Evaluate(ctx));
+
+        EXPECT_EQ(7, result->getIntValue());
+    }
+
+    // ( 1 + 2 * 3 ) % 5 == 2
+    {
+        std::shared_ptr<Expression> _1 = std::make_shared<ValueExpression>(SignedIntValue::Create(S32, 1));
+        std::shared_ptr<Expression> _2 = std::make_shared<ValueExpression>(SignedIntValue::Create(S32, 2));
+        std::shared_ptr<Expression> _3 = std::make_shared<ValueExpression>(SignedIntValue::Create(S32, 3));
+        std::shared_ptr<Expression> _5 = std::make_shared<ValueExpression>(SignedIntValue::Create(S32, 5));
+
+        std::shared_ptr<Expression> mul_expr = std::make_shared<BinaryExpression>(Expression::EXP_MUL, _2, _3);
+        std::shared_ptr<Expression> add_expr = std::make_shared<BinaryExpression>(Expression::EXP_ADD, _1, mul_expr);
+
+        std::shared_ptr<Expression> mod_expr = std::make_shared<BinaryExpression>(Expression::EXP_MOD, add_expr, _5);
+
+        std::shared_ptr<SignedIntValue> result = std::dynamic_pointer_cast<SignedIntValue>(mod_expr->Evaluate(ctx));
+
+        EXPECT_EQ(2, result->getIntValue());
+    }
+
+    // 2 * 3.5 / 3
+    {
+        std::shared_ptr<Expression> _2 = std::make_shared<ValueExpression>(SignedIntValue::Create(S64, 2));
+        std::shared_ptr<Expression> _3_5 = std::make_shared<ValueExpression>(FloatValue::Create(F64, 3.5));
+        std::shared_ptr<Expression> _3 = std::make_shared<ValueExpression>(SignedIntValue::Create(S64, 3));
+
+        std::shared_ptr<Expression> mul_expr = std::make_shared<BinaryExpression>(Expression::EXP_MUL, _2, _3_5);
+        std::shared_ptr<Expression> div_expr = std::make_shared<BinaryExpression>(Expression::EXP_DIV, mul_expr, _3);
+
+        std::shared_ptr<FloatValue> result = std::dynamic_pointer_cast<FloatValue>(div_expr->Evaluate(ctx));
+
+        EXPECT_EQ( (2 * 3.5 / 3) , result->getFloatValue());
+    }
+
+}
+
+TEST (ASTTest, Expression_Int_Compare) {
+
+    {
+        std::shared_ptr<Expression> _2 = std::make_shared<ValueExpression>(SignedIntValue::Create(S32, 2));
+        std::shared_ptr<Expression> _3 = std::make_shared<ValueExpression>(SignedIntValue::Create(S32, 3));
+
+        std::shared_ptr<Expression> eql_expr = std::make_shared<BinaryExpression>(Expression::EXP_EQL, _2, _3);
+        std::shared_ptr<Expression> neq_expr = std::make_shared<BinaryExpression>(Expression::EXP_NEQ, _2, _3);
+        std::shared_ptr<Expression> lss_expr = std::make_shared<BinaryExpression>(Expression::EXP_LSS, _2, _3);
+        std::shared_ptr<Expression> gtr_expr = std::make_shared<BinaryExpression>(Expression::EXP_GTR, _2, _3);
+        std::shared_ptr<Expression> leq_expr = std::make_shared<BinaryExpression>(Expression::EXP_LEQ, _2, _3);
+        std::shared_ptr<Expression> geq_expr = std::make_shared<BinaryExpression>(Expression::EXP_GEQ, _2, _3);
+
+        std::shared_ptr<SignedIntValue> result = std::dynamic_pointer_cast<SignedIntValue>(eql_expr->Evaluate(ctx));
+        EXPECT_FALSE(result->getIntValue());
+        result = std::dynamic_pointer_cast<SignedIntValue>(neq_expr->Evaluate(ctx));
+        EXPECT_TRUE(result->getIntValue());
+        result = std::dynamic_pointer_cast<SignedIntValue>(lss_expr->Evaluate(ctx));
+        EXPECT_TRUE(result->getIntValue());
+        result = std::dynamic_pointer_cast<SignedIntValue>(gtr_expr->Evaluate(ctx));
+        EXPECT_FALSE(result->getIntValue());
+        result = std::dynamic_pointer_cast<SignedIntValue>(leq_expr->Evaluate(ctx));
+        EXPECT_TRUE(result->getIntValue());
+        result = std::dynamic_pointer_cast<SignedIntValue>(geq_expr->Evaluate(ctx));
+        EXPECT_FALSE(result->getIntValue());
+
+    }
+}
+
+TEST (ASTTest, Expression_Float_Compare) {
+
+    const double __2_5 = 2.000000000005;
+    const double __2_7 = 2.000000000007;
+
+    {
+        std::shared_ptr<Expression> _2_5 = std::make_shared<ValueExpression>(FloatValue::Create(F32, __2_5));
+        std::shared_ptr<Expression> _2_7 = std::make_shared<ValueExpression>(FloatValue::Create(F32, __2_7));
+
+        std::shared_ptr<Expression> eql_expr = std::make_shared<BinaryExpression>(Expression::EXP_EQL, _2_5, _2_7);
+        std::shared_ptr<Expression> neq_expr = std::make_shared<BinaryExpression>(Expression::EXP_NEQ, _2_5, _2_7);
+        std::shared_ptr<Expression> lss_expr = std::make_shared<BinaryExpression>(Expression::EXP_LSS, _2_5, _2_7);
+        std::shared_ptr<Expression> gtr_expr = std::make_shared<BinaryExpression>(Expression::EXP_GTR, _2_5, _2_7);
+        std::shared_ptr<Expression> leq_expr = std::make_shared<BinaryExpression>(Expression::EXP_LEQ, _2_5, _2_7);
+        std::shared_ptr<Expression> geq_expr = std::make_shared<BinaryExpression>(Expression::EXP_GEQ, _2_5, _2_7);
+
+        std::shared_ptr<FloatValue> result = std::dynamic_pointer_cast<FloatValue>(eql_expr->Evaluate(ctx));
+        EXPECT_FALSE(result->getFloatValue());
+        result = std::dynamic_pointer_cast<FloatValue>(neq_expr->Evaluate(ctx));
+        EXPECT_TRUE(result->getFloatValue());
+        result = std::dynamic_pointer_cast<FloatValue>(lss_expr->Evaluate(ctx));
+        EXPECT_TRUE(result->getFloatValue());
+        result = std::dynamic_pointer_cast<FloatValue>(gtr_expr->Evaluate(ctx));
+        EXPECT_FALSE(result->getFloatValue());
+        result = std::dynamic_pointer_cast<FloatValue>(leq_expr->Evaluate(ctx));
+        EXPECT_TRUE(result->getFloatValue());
+        result = std::dynamic_pointer_cast<FloatValue>(geq_expr->Evaluate(ctx));
+        EXPECT_FALSE(result->getFloatValue());
+
+    }
+}
+
+TEST (ASTTest, Expression_Float_EQL_Compare) {
+
+    const double a = 0.15 + 0.15;
+    const double b = 0.1 + 0.2;
+
+    std::shared_ptr<Expression> a_ = std::make_shared<ValueExpression>(FloatValue::Create(F64, a));
+    std::shared_ptr<Expression> b_ = std::make_shared<ValueExpression>(FloatValue::Create(F64, b));
+
+    std::shared_ptr<Expression> eql_expr = std::make_shared<BinaryExpression>(Expression::EXP_EQL, a_, b_);
+    std::shared_ptr<Expression> neq_expr = std::make_shared<BinaryExpression>(Expression::EXP_NEQ, a_, b_);
+    std::shared_ptr<Expression> leq_expr = std::make_shared<BinaryExpression>(Expression::EXP_LEQ, a_, b_);
+
+    // a == b
+    std::shared_ptr<FloatValue> result = std::dynamic_pointer_cast<FloatValue>(eql_expr->Evaluate(ctx));
+    EXPECT_TRUE(result->getFloatValue());
+
+    // a != b
+    result = std::dynamic_pointer_cast<FloatValue>(neq_expr->Evaluate(ctx));
+    EXPECT_FALSE(result->getFloatValue());
+
+    // a <= b
+    result = std::dynamic_pointer_cast<FloatValue>(leq_expr->Evaluate(ctx));
+    EXPECT_TRUE(result->getFloatValue());
+
+}


### PR DESCRIPTION
Value클래스를 상속받은 파생클래스들을 만들었습니다. 각 타입마다 클래스를 하나씩 파생시켰습니다. 이들은 yacc에서 지정한 rule과 매치되면 실행하는 action부분에서 트리구조로 생성될 것입니다.

Value클래스들의 생성자는 protected로 선언되었고, 외부에서 접근 할 수 없습니다. Value클래스들의 객체를 만들기 위해서는 각 자식 클래스에 구현된 팩토리 함수 'Create'를 사용해야 합니다. 이는 Value클래스들을 생성하면서 TypeSpecifier가 올바른 클래스에 지정되었는지 확인하기 위함입니다. 현재 SignedIntValue 클래스에 'F32' 타입을 넣었을때 객체가 제대로 생성되지 않습니다.

현재까지 구현된 SignedIntValue와 FloatValue 만 추가했습니다. 다른 클래스들은 구현되는대로 추가하겠습니다.

SignedIntValue와 FloatIntValue에 대한 테스트 코드를 추가했습니다.

FloatValue의 동등비교에서 epsilon을 이용한 비교를 합니다.
