### PR TITLE
VM: Added Statement::Type enum

### DIFF
--- a/include/ast/statement/block.h
+++ b/include/ast/statement/block.h
@@ -13,6 +13,7 @@ namespace apus {
         Block(std::shared_ptr<Statement> statement);
         virtual ~Block();
 
+        virtual Type getType() override { return STMT_BLOCK; }
         virtual void Execute(Context& context) override;
 
     private:

--- a/include/ast/statement/expression_statement.h
+++ b/include/ast/statement/expression_statement.h
@@ -15,6 +15,7 @@ namespace apus {
         ExpressionStatement(Expression* expression);
         virtual ~ExpressionStatement();
 
+        virtual Type getType() override { return STMT_EXPR; }
         virtual void Execute(Context& context) override;
 
     private:

--- a/include/ast/statement/for_statement.h
+++ b/include/ast/statement/for_statement.h
@@ -25,6 +25,7 @@ namespace apus {
 
         virtual ~ForStatement ();
 
+        virtual Type getType() override { return STMT_FOR; }
         virtual void Execute(Context& context) override;
 
     private:

--- a/include/ast/statement/if_statement.h
+++ b/include/ast/statement/if_statement.h
@@ -21,6 +21,7 @@ namespace apus {
 
         virtual ~IfStatement();
 
+        virtual Type getType() override { return STMT_IF; }
         virtual void Execute(Context& context) override;
 
     private:

--- a/include/ast/statement/jump_statement.h
+++ b/include/ast/statement/jump_statement.h
@@ -16,6 +16,7 @@ namespace apus {
         BreakStatement() {}
         virtual ~BreakStatement() {}
 
+        virtual Type getType() override { return STMT_BREAK; }
         virtual void Execute(Context& context) override;
 
     };
@@ -26,6 +27,7 @@ namespace apus {
         ContinueStatement() {}
         virtual ~ContinueStatement() {}
 
+        virtual Type getType() override { return STMT_CONTINUE; }
         virtual void Execute(Context& context) override;
 
     };
@@ -38,6 +40,7 @@ namespace apus {
 
         virtual ~ReturnStatement() {}
 
+        virtual Type getType() override { return STMT_RETURN; }
         virtual void Execute(Context& context) override;
 
     private:
@@ -53,6 +56,7 @@ namespace apus {
         ExitStatement(Expression* expression);
         virtual ~ExitStatement() {}
 
+        virtual Type getType() override { return STMT_EXIT; }
         virtual void Execute(Context& context) override;
 
     private:

--- a/include/ast/statement/statement.h
+++ b/include/ast/statement/statement.h
@@ -7,10 +7,23 @@ namespace apus {
 
     class Statement {
     public:
+
+        enum Type {
+            STMT_BLOCK = 0,
+            STMT_EXPR,
+            STMT_IF,
+            STMT_FOR,
+            STMT_BREAK,
+            STMT_CONTINUE,
+            STMT_RETURN,
+            STMT_EXIT,
+            STMT_VAR_DEF,
+        };
         
         Statement() {}
         virtual ~Statement() {}
-        
+
+        virtual Type getType() = 0;
         virtual void Execute(Context& context) = 0;
 
     private:

--- a/include/ast/statement/var_def_statement.h
+++ b/include/ast/statement/var_def_statement.h
@@ -13,6 +13,7 @@ namespace apus {
         VarDefStatement();
         virtual ~VarDefStatement();
 
+        virtual Type getType() override { return STMT_VAR_DEF; }
         void Execute(Context& context) override;
 
     private:


### PR DESCRIPTION
어떤 Statement\* 가 가리키고 있는 대상이 실제로 어떤 인스턴스인지 알기 위해, 각 Statement에 해당하는 enum을 (Statement::Type) 정의하고 이를 반환하는 함수 Statement::getType()을 순수가상함수로 만들어줬습니다. 모든 자식클래스에서 각자가 해당하는 enum을 반환하도록 정의했습니다.
