### PR TITLE
parser: pctx-v2

### DIFF
--- a/include/parser_context.h
+++ b/include/parser_context.h
@@ -1,0 +1,23 @@
+#include <list>
+#include <memory>
+
+namespace apus {
+
+    class VirtualMachine;
+
+    class ParserContext {
+    public:
+        ParserContext(std::shared_ptr<VirtualMachine> vm = nullptr);
+        ~ParserContext();
+
+        std::shared_ptr<VirtualMachine> getVM();
+
+        void setVM(std::shared_ptr<VirtualMachine> vm);
+
+    private:
+
+        std::shared_ptr<VirtualMachine> vm_;
+
+    };
+
+}

--- a/src/apus.l
+++ b/src/apus.l
@@ -1,5 +1,7 @@
 %{
 #include <stdio.h>
+
+#include "parser_context.h"
 #include "y.tab.hh"
 
 %}

--- a/src/apus.y
+++ b/src/apus.y
@@ -2,10 +2,17 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "parser_context.h"
+
 extern int yylex();
-extern int yyerror(char const *str);
+extern int yyerror(apus::ParserContext* pctx, char const *str);
 
 %}
+
+%parse-param {
+    apus::ParserContext* pctx
+}
+
 %code requires {
     #include "common/common.h"
 }
@@ -253,7 +260,7 @@ array_init :
     L_CASE init_expression_list R_CASE
     ;
 %%
-int yyerror(char const *str) {
+int yyerror(apus::ParserContext* pctx, char const *str) {
     extern char yylineno;
     extern char *yytext;
     fprintf(stderr, "parser error near %s, line is %d\n", yytext, yylineno);

--- a/src/parser_context.cpp
+++ b/src/parser_context.cpp
@@ -1,0 +1,23 @@
+#include "parser_context.h"
+#include "vm/virtual_machine.h"
+
+namespace apus {
+
+    ParserContext::ParserContext(std::shared_ptr<VirtualMachine> vm)
+        : vm_(vm) {
+
+    }
+
+    ParserContext::~ParserContext() {
+
+    }
+
+    std::shared_ptr<VirtualMachine> ParserContext::getVM() {
+        return vm_;
+    }
+
+    void ParserContext::setVM(std::shared_ptr<VirtualMachine> vm) {
+        vm_ = vm;
+    }
+
+}

--- a/test/parser/array_test.cpp
+++ b/test/parser/array_test.cpp
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
+#include "parser_context.h"
 
-extern int yyparse(void);
+extern int yyparse(apus::ParserContext* pctx);
 extern int yy_scan_string(const char *);
 
 // test_x x number is defined sub test
@@ -42,28 +43,30 @@ var struct id2[2][2][2] ll = [[[{1, 2}, {3, 4}], [{5, 6}, {7, 8}]],\n\
 
 TEST (ParserTest, ArrayCorrectTest) {
     int result;
+    apus::ParserContext pctx;
 
     yy_scan_string(one_dimension_test_1);
-    result = yyparse();
+    result = yyparse(&pctx);
     EXPECT_EQ (result, 0);
 
     yy_scan_string(two_dimension_test_1);
-    result = yyparse();
+    result = yyparse(&pctx);
     EXPECT_EQ (result, 0);
 
     yy_scan_string(three_dimension_test_1);
-    result = yyparse();
+    result = yyparse(&pctx);
     EXPECT_EQ (result, 0);
 
     yy_scan_string(used_array_test_1);
-    result = yyparse();
+    result = yyparse(&pctx);
     EXPECT_EQ (result, 0);
 }
 
 TEST (ParserTest, ArrayCRTest) {
     int result;
+    apus::ParserContext pctx;
 
     yy_scan_string(three_dimension_test_3);
-    result = yyparse();
+    result = yyparse(&pctx);
     EXPECT_EQ (result, 0);
 }

--- a/test/parser/data_decl_test.cpp
+++ b/test/parser/data_decl_test.cpp
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
+#include "parser_context.h"
 
-extern int yyparse(void);
+extern int yyparse(apus::ParserContext* pctx);
 extern int yy_scan_string(const char *);
 
 static char data_decl_test[] = "\
@@ -33,9 +34,11 @@ union id6 { u32 aa }\n\
 ";
 
 TEST (ParserTest, DataDeclTest) {
+    int result;
+    apus::ParserContext pctx;
 
     yy_scan_string(data_decl_test);
-    int result = yyparse();
+    result = yyparse(&pctx);
 
     EXPECT_EQ (result, 0);
 }

--- a/test/parser/statement_test.cpp
+++ b/test/parser/statement_test.cpp
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
+#include "parser_context.h"
 
-extern int yyparse(void);
+extern int yyparse(apus::ParserContext* pctx);
 extern int yy_scan_string(const char *);
 
 // test_x x number is defined sub test
@@ -79,34 +80,39 @@ else { }                \n\
 ";
 
 TEST (ParserTest, StmtCorrectTest) {
+    int result;
+    apus::ParserContext pctx;
+
     yy_scan_string(var_def_test_1);
-    int result = yyparse();
+    result = yyparse(&pctx);
     EXPECT_EQ (result, 0);
 
     yy_scan_string(jump_stmt_test_1);
-    result = yyparse();
+    result = yyparse(&pctx);
     EXPECT_EQ (result, 0);
 
     yy_scan_string(for_stmt_test_1);
-    result = yyparse();
+    result = yyparse(&pctx);
     EXPECT_EQ (result, 0);
 
     yy_scan_string(if_stmt_test_1);
-    result = yyparse();
+    result = yyparse(&pctx);
     EXPECT_EQ (result, 0);
 
     yy_scan_string(expr_stmt_test_1);
-    result = yyparse();
+    result = yyparse(&pctx);
     EXPECT_EQ (result, 0);
 
     yy_scan_string(block_stmt_test_1);
-    result = yyparse();
+    result = yyparse(&pctx);
     EXPECT_EQ (result, 0);
 }
 
 TEST (ParserTest, StmtLineTest) {
     int result;
+    apus::ParserContext pctx;
+
     yy_scan_string(if_stmt_test_3);
-    result = yyparse();
+    result = yyparse(&pctx);
     EXPECT_EQ (result, 0);
 }


### PR DESCRIPTION
parser_context 관련 .h와 .cpp파일을 추가하였습니다.

또한, yyparse()에 재진입성을 가능케하여 인자를 줄 수 있습니다.
- 따라서 현재 ParserContext객체를 yyparse() 인자로 전달이 가능합니다.

v2
- 쓸모없는 파일을 commit 에서 제외했습니다.
