### PR TITLE
Jeongmin/vm/data type table v2

### DIFF
--- a/include/common/common.h
+++ b/include/common/common.h
@@ -1,6 +1,8 @@
 #ifndef __COMMON_H__
 #define __COMMON_H__
 
+#include <string>
+#include <iostream>
 #include <stdint.h>
 #include <inttypes.h>
 
@@ -26,6 +28,13 @@ namespace apus {
         USER_DEFINED,       // User-defined type
         NOT_DEFINED,        // Not-defined type
     } TypeSpecifier;
+
+    const std::string ToString[C32+1] = {
+        "U8", "U16", "U32", "U64",
+        "S8", "S16", "S32", "S64",
+        "F32", "F64",
+        "C8", "C16", "C32",
+    };
 
     int TypeLength (TypeSpecifier type);
 

--- a/include/common/common.h
+++ b/include/common/common.h
@@ -25,7 +25,7 @@ namespace apus {
         C8, C16, C32,       // Character Type
         STR8, STR16, STR32, // String Type
         STRUCT, UNION,      // Struct and Union
-        ARRAY,              // Struct
+        ARRAY,              // Array
         STRUCT_ARRAY,       // Struct Array
         USER_DEFINED,       // User-defined type
         NOT_DEFINED,        // Not-defined type

--- a/include/common/common.h
+++ b/include/common/common.h
@@ -14,17 +14,20 @@ namespace apus {
         BIG = 0x01020304ul,
     } Endian;
 
-    enum TypeSpecifier {
+    typedef enum {
         U8, U16, U32, U64,  // Unsigned Integer
         S8, S16, S32, S64,  // Signed Integer
         F32, F64,           // Floating Point Real Number
         C8, C16, C32,       // Character Type
         STR8, STR16, STR32, // String Type
-    };
+        STRUCT, UNION,      // Struct and Union
+        ARRAY,              // Struct
+        STRUCT_ARRAY,       // Struct Array
+        USER_DEFINED,       // User-defined type
+        NOT_DEFINED,        // Not-defined type
+    } TypeSpecifier;
 
-    typedef enum TypeSpecifier VarType;
-
-    int TypeLength(VarType type);
+    int TypeLength (TypeSpecifier type);
 
     inline int HostEndian() {
 

--- a/include/common/common.h
+++ b/include/common/common.h
@@ -8,6 +8,8 @@
 
 namespace apus {
 
+    #define ERROR_MSG   true
+
     typedef char byte;
 
     typedef enum {
@@ -46,6 +48,12 @@ namespace apus {
         } HostOrder = {{1, 2, 3, 4}};
 
         return HostOrder.value;
+    }
+
+    inline void DispErr(std::string err) {
+        if (ERROR_MSG) {
+            std::cout << err << std::endl;
+        }
     }
 }
 

--- a/include/utils/BinaryReader.h
+++ b/include/utils/BinaryReader.h
@@ -11,30 +11,23 @@ namespace apus {
     class BinaryReader {
     public:
         BinaryReader();
-
         BinaryReader(string &file_name);
-
         ~BinaryReader();
 
         Endian GetFileEndian();
-
         void SetFileEndian(Endian endian);
 
-        int ReadInt(streampos offset, VarType type, uint64_t &out_int);
+        int ReadInt(streampos offset, TypeSpecifier type, uint64_t &out_int);
+        int ReadInt(TypeSpecifier type, uint64_t &out_int);
 
-        int ReadInt(VarType type, uint64_t &out_int);
+        int ReadReal(streampos offset, TypeSpecifier type, double &out_real);
+        int ReadReal(TypeSpecifier type, double &out_real);
 
-        int ReadReal(streampos offset, VarType type, double &out_real);
+        int ReadChar(streampos offset, TypeSpecifier type, uint32_t &out_char);
+        int ReadChar(TypeSpecifier type, uint32_t &out_char);
 
-        int ReadReal(VarType type, double &out_real);
-
-        int ReadChar(streampos offset, VarType type, uint32_t &out_char);
-
-        int ReadChar(VarType type, uint32_t &out_char);
-
-        int ReadString(streampos offset, VarType type, string &out_str);
-
-        int ReadString(VarType type, string &out_str);
+        int ReadString(streampos offset, TypeSpecifier type, string &out_str);
+        int ReadString(TypeSpecifier type, string &out_str);
 
     private:
         string file_name_;                  // file name

--- a/include/vm/data_type_table.h
+++ b/include/vm/data_type_table.h
@@ -1,0 +1,83 @@
+#ifndef DATA_TYPE_TABLE_H_
+#define DATA_TYPE_TABLE_H_
+
+#include "common/common.h"
+#include "ast/expression.h"
+#include <memory>
+#include <string>
+#include <list>
+#include <map>
+using namespace std;
+
+namespace apus {
+
+    class DataType;
+    class Expression;
+
+    typedef std::shared_ptr<DataType> DataTypePtr;
+    typedef std::shared_ptr<Expression> ExprPtr;
+    typedef std::map< std::string, DataTypePtr > DataTypeMap;
+
+    class DataType {
+
+    public:
+        DataType();
+        DataType(TypeSpecifier type);
+        ~DataType();
+
+        void Insert(const std::string& name, DataType* elem);
+        void Insert(const std::string& name, DataTypePtr elem);
+        DataTypePtr Find(const std::string& name);
+
+        void SetByteSize(int byte_size);
+        int GetByteSize();
+
+        void SetInitExpr(Expression* expr);
+        ExprPtr GetInitExpr();
+
+        void SetType(TypeSpecifier type);
+        TypeSpecifier GetType();
+
+        bool HasChild();
+
+        // For an array data type
+        bool IsArray();
+
+        void AddDimension(int dim);
+        std::list<int> GetDimensionList();
+
+        void SetArraySize(int array_size);
+        int GetArraySize();
+
+    private:
+
+        TypeSpecifier type_;            // type of the data type
+        DataTypeMap map_;               // list of child data types
+        int byte_size_;                 // size of bytes to be assigned
+        int offset_;                    // offset in list of parent data type
+        ExprPtr init_expr_;             // expression to be initialized
+
+        // For an array data type
+        int array_size_;                // product of dimension sizes
+        std::list<int> dimension_list_; // containing size of each dimension 
+    };
+
+    class DataTypeTable {
+    
+    public:
+        DataTypeTable();
+        ~DataTypeTable();
+
+        void Insert(const std::string& name, DataType* elem);
+        void Insert(const std::string& name, DataTypePtr elem);
+        DataTypePtr Find(const std::string& name);
+        DataTypePtr Find(TypeSpecifier type);
+
+    private:
+        DataTypeMap map_;
+    };
+
+    typedef std::shared_ptr<DataTypeTable> DataTypeTablePtr;
+}
+
+#endif

--- a/include/vm/data_type_table.h
+++ b/include/vm/data_type_table.h
@@ -30,7 +30,7 @@ namespace apus {
         DataTypePtr Find(const std::string& name);
 
         void SetByteSize(int byte_size);
-        int GetByteSize();
+        virtual int GetByteSize();
 
         void SetInitExpr(Expression* expr);
         ExprPtr GetInitExpr();
@@ -40,8 +40,22 @@ namespace apus {
 
         bool HasChild();
 
-        // For an array data type
+    protected:
+        TypeSpecifier type_;            // type of the data type
+        DataTypeMap map_;               // list of child data types
+        int byte_size_;                 // size of bytes to be assigned
+        int offset_;                    // offset in list of parent data type
+        ExprPtr init_expr_;             // expression to be initialized
+    };
+
+    class ArrayDataType : public DataType {
+    public:
+        ArrayDataType();
+        ArrayDataType(TypeSpecifier type);
+        ~ArrayDataType();
+
         bool IsArray();
+        int GetByteSize() override;
 
         void AddDimension(int dim);
         std::list<int> GetDimensionList();
@@ -49,17 +63,14 @@ namespace apus {
         void SetArraySize(int array_size);
         int GetArraySize();
 
-    private:
+        void SetElement(DataTypePtr elem);
+        void SetElement(DataType* elem);
+        DataTypePtr GetElement() const;
 
-        TypeSpecifier type_;            // type of the data type
-        DataTypeMap map_;               // list of child data types
-        int byte_size_;                 // size of bytes to be assigned
-        int offset_;                    // offset in list of parent data type
-        ExprPtr init_expr_;             // expression to be initialized
-
-        // For an array data type
+    private: 
         int array_size_;                // product of dimension sizes
-        std::list<int> dimension_list_; // containing size of each dimension 
+        std::list<int> dimension_list_; // size of each dimension
+        DataTypePtr elem_data_type_;    // element data type
     };
 
     class DataTypeTable {
@@ -68,10 +79,14 @@ namespace apus {
         DataTypeTable();
         ~DataTypeTable();
 
+        void SetPrimitiveTypes();
+
         void Insert(const std::string& name, DataType* elem);
         void Insert(const std::string& name, DataTypePtr elem);
+
         DataTypePtr Find(const std::string& name);
         DataTypePtr Find(TypeSpecifier type);
+
 
     private:
         DataTypeMap map_;

--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -4,7 +4,7 @@ using namespace std;
 
 namespace apus {
 
-    int TypeLength(VarType type) {
+    int TypeLength(TypeSpecifier type) {
         int length = 0;
         switch (type) {
             case U8:
@@ -38,7 +38,7 @@ namespace apus {
                 length = 0; // not fixed. variable-length
                 break;
 
-                // exception
+            // exception
             default:
                 cout << "There's no matched variable type." << endl;
                 length = -1;

--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -40,7 +40,7 @@ namespace apus {
 
             // exception
             default:
-                cout << "There's no matched variable type." << endl;
+                DispErr("There's no matched variable type.");
                 length = -1;
                 break;
         }

--- a/src/utils/BinaryReader.cpp
+++ b/src/utils/BinaryReader.cpp
@@ -57,7 +57,7 @@ namespace apus {
         }
     }
 
-    int BinaryReader::ReadInt(streampos pos, VarType type, uint64_t &out_int) {
+    int BinaryReader::ReadInt(streampos pos, TypeSpecifier type, uint64_t &out_int) {
 
         // If it's not proper type, return -1
         if (type != U8 && type != U16 && type != U32 && type != U64 &&
@@ -86,12 +86,12 @@ namespace apus {
         return 0;
     }
 
-    int BinaryReader::ReadInt(VarType type, uint64_t &out_int) {
+    int BinaryReader::ReadInt(TypeSpecifier type, uint64_t &out_int) {
 
         return ReadInt(file_stream_.tellg(), type, out_int);
     }
 
-    int BinaryReader::ReadReal(streampos pos, VarType type, double &out_real) {
+    int BinaryReader::ReadReal(streampos pos, TypeSpecifier type, double &out_real) {
 
         // If it's not proper type, return -1
         if (type != F32 && type != F64) {
@@ -124,12 +124,12 @@ namespace apus {
         return 0;
     }
 
-    int BinaryReader::ReadReal(VarType type, double &out_real) {
+    int BinaryReader::ReadReal(TypeSpecifier type, double &out_real) {
 
         return ReadReal(file_stream_.tellg(), type, out_real);
     }
 
-    int BinaryReader::ReadChar(streampos pos, VarType type,
+    int BinaryReader::ReadChar(streampos pos, TypeSpecifier type,
                                uint32_t &out_char) {
 
         // If it's not proper type, return -1
@@ -159,15 +159,15 @@ namespace apus {
         return 0;
     }
 
-    int BinaryReader::ReadChar(VarType type, uint32_t &out_char) {
+    int BinaryReader::ReadChar(TypeSpecifier type, uint32_t &out_char) {
 
         return ReadChar(file_stream_.tellg(), type, out_char);
     }
 
-    int BinaryReader::ReadString(streampos pos, VarType type, string &out_str) {
+    int BinaryReader::ReadString(streampos pos, TypeSpecifier type, string &out_str) {
 
         uint32_t read = 0;                  // read character
-        VarType char_type;                  // type of a character
+        TypeSpecifier char_type;                  // type of a character
 
         // assign type of a character
         if (type == STR8) {
@@ -201,7 +201,7 @@ namespace apus {
         return 0;
     }
 
-    int BinaryReader::ReadString(VarType type, string &out_char) {
+    int BinaryReader::ReadString(TypeSpecifier type, string &out_char) {
 
         return ReadString(file_stream_.tellg(), type, out_char);
     }

--- a/src/utils/BinaryReader.cpp
+++ b/src/utils/BinaryReader.cpp
@@ -14,7 +14,7 @@ namespace apus {
                 out_array[(length - 1) - i] = temp;
             }
         } catch (std::exception &e) {
-            cout << "Out of Range error: " << endl;
+            DispErr("Out of Range error");
             return -1;
         }
         return 0;
@@ -33,8 +33,8 @@ namespace apus {
         // open the file in binary instream manner
         file_stream_.open(file_name_, ios::in | ios::binary);
         if (!file_stream_.is_open()) {
-            cout << "There's no file with name: " << file_name << endl;
-            cout << "Program will exit." << endl;
+            DispErr("There's no file with name: " + file_name);
+            DispErr("Program will exit.");
             exit(-1);
         }
     }

--- a/src/vm/data_type_table.cpp
+++ b/src/vm/data_type_table.cpp
@@ -8,7 +8,6 @@ namespace apus {
     DataType::DataType() {
         byte_size_ = 0;
         offset_ = 0;
-        array_size_ = 0;
     }
 
     DataType::DataType(TypeSpecifier type): DataType() {
@@ -56,13 +55,8 @@ namespace apus {
                 }
                 byte_size_ = byte_size;
             }
-            // case array
-            if (array_size_ > 1) {
-                byte_size_ = byte_size_ * array_size_;
-            } else if (dimension_list_.size() >= 1) {
-                byte_size_ = byte_size_ * GetArraySize();
-            }
         }
+        // If byte_size_ is set, just return it
         return byte_size_;
     }
     
@@ -91,7 +85,22 @@ namespace apus {
         }
     }
 
-    bool DataType::IsArray() {
+    // ArrayDataType class
+
+    ArrayDataType::ArrayDataType() : DataType() {
+        array_size_ = 0;
+    }
+
+    ArrayDataType::ArrayDataType(TypeSpecifier type) 
+        : DataType(type) {
+        array_size_ = 0;
+    }
+
+    ArrayDataType::~ArrayDataType() {
+    }
+
+
+    bool ArrayDataType::IsArray() {
         if (dimension_list_.size() > 0) {
             if (array_size_ <= 1) {
                 GetArraySize();
@@ -102,19 +111,35 @@ namespace apus {
         }
     }
 
-    void DataType::AddDimension(int dim) {
+    int ArrayDataType::GetByteSize() {
+        int byte_size = elem_data_type_->GetByteSize();
+        // If byte_size is not set
+        if (byte_size > 0) {
+            // If array_size_ is set
+            if (array_size_ > 1) {
+                byte_size_ = byte_size * array_size_;
+            // If array_size_ is not set
+            } else if (dimension_list_.size() > 0) {
+                byte_size_ = byte_size * GetArraySize();
+            }
+        }
+        // If byte_size is set, just return it
+        return byte_size_;
+    }
+
+    void ArrayDataType::AddDimension(int dim) {
         dimension_list_.push_front (dim);
     }
 
-    std::list<int> DataType::GetDimensionList() {
+    std::list<int> ArrayDataType::GetDimensionList() {
         return dimension_list_;
     }
 
-    void DataType::SetArraySize(int array_size) {
+    void ArrayDataType::SetArraySize(int array_size) {
         array_size_ = array_size;
     }
 
-    int DataType::GetArraySize() {
+    int ArrayDataType::GetArraySize() {
         // If array_size_ is not set
         if (array_size_ <= 1 && dimension_list_.size() > 0) {
             int array_size = 1;
@@ -133,23 +158,37 @@ namespace apus {
         return array_size_;
     }
 
+    void ArrayDataType::SetElement(DataTypePtr elem) {
+        elem_data_type_ = elem;
+    }
+
+    void ArrayDataType::SetElement(DataType* elem) {
+        // pointer to shared_ptr
+        elem_data_type_ = std::make_shared<DataType>(*elem);
+    }
+
+    DataTypePtr ArrayDataType::GetElement() const {
+        return elem_data_type_;
+    }
+
     // DataTypeTable class
 
     DataTypeTable::DataTypeTable() {
-        int cur = U8;
-        // Add primitive types into data type table's map
-        for (cur = U8; cur <= C32; cur++) {
-            TypeSpecifier type = (TypeSpecifier)cur;
-            map_[apus::ToString[type]] = 
-                std::make_shared<DataType>(type);
-        }
     }
 
     DataTypeTable::~DataTypeTable() {
     }
 
+    void DataTypeTable::SetPrimitiveTypes() {
+        // Add primitive types into data type table's map
+        for (int i = U8; i <= C32; i++) {
+            TypeSpecifier type = (TypeSpecifier) i;
+            map_[apus::ToString[type]] = std::make_shared<DataType>(type);
+        }
+    }
+
     void DataTypeTable::Insert(const std::string& name, DataType* elem) {
-        DataTypePtr elem_ptr(elem);
+        DataTypePtr elem_ptr = std::make_shared<DataType>(*elem);
         map_[name] = elem_ptr;
     }
 

--- a/src/vm/data_type_table.cpp
+++ b/src/vm/data_type_table.cpp
@@ -1,0 +1,176 @@
+#include "vm/data_type_table.h"
+#include <iostream>
+
+namespace apus {
+
+    // DataType class
+
+    DataType::DataType() {
+        byte_size_ = 0;
+        offset_ = 0;
+        array_size_ = 0;
+    }
+
+    DataType::DataType(TypeSpecifier type): DataType() {
+        type_ = type;
+    }
+
+    DataType::~DataType() {
+    }
+
+    void DataType::Insert(const std::string& name, DataType* elem) {
+        DataTypePtr elem_ptr(elem); // pointer to shared_ptr
+        map_[name] = elem_ptr;
+    }
+
+    void DataType::Insert(const std::string& name, DataTypePtr elem) {
+        map_[name] = elem;
+    }
+
+    DataTypePtr DataType::Find(const std::string& name) {
+        DataTypeMap::iterator it = map_.find(name);
+        if (it != map_.end()) {
+            return it->second;
+        }
+        return nullptr;
+    }
+
+    void DataType::SetByteSize(int byte_size) {
+        byte_size_ = byte_size;
+    }
+
+    int DataType::GetByteSize() {
+        int type_length = apus::TypeLength(type_);
+        // If byte_size_ is not set
+        if (byte_size_ == 0) {
+            // If primitive types, get TypeLength() value
+            if (type_length > 0) {
+                byte_size_ = type_length;
+            // If not primitive types (e.g. struct)
+            } else {
+                int byte_size = 0;
+                // get sum of byte size of child data types
+                for (DataTypeMap::iterator it = map_.begin();
+                    it != map_.end(); it++) {
+                    byte_size += it->second->GetByteSize();
+                }
+                byte_size_ = byte_size;
+            }
+            // case array
+            if (array_size_ > 1) {
+                byte_size_ = byte_size_ * array_size_;
+            } else if (dimension_list_.size() >= 1) {
+                byte_size_ = byte_size_ * GetArraySize();
+            }
+        }
+        return byte_size_;
+    }
+    
+    void DataType::SetInitExpr(Expression* expr_ptr) {
+        // pointer to shared_ptr
+        init_expr_ = ExprPtr (expr_ptr);
+    }
+
+    ExprPtr DataType::GetInitExpr() {
+        return init_expr_;
+    }
+
+    void DataType::SetType(TypeSpecifier type) {
+        type_ = type;
+    }
+
+    TypeSpecifier DataType::GetType() {
+        return type_;
+    }
+
+    bool DataType::HasChild() {
+        if (map_.size() != 0) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    bool DataType::IsArray() {
+        if (dimension_list_.size() > 0) {
+            if (array_size_ <= 1) {
+                GetArraySize();
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    void DataType::AddDimension(int dim) {
+        dimension_list_.push_front (dim);
+    }
+
+    std::list<int> DataType::GetDimensionList() {
+        return dimension_list_;
+    }
+
+    void DataType::SetArraySize(int array_size) {
+        array_size_ = array_size;
+    }
+
+    int DataType::GetArraySize() {
+        // If array_size_ is not set
+        if (array_size_ <= 1 && dimension_list_.size() > 0) {
+            int array_size = 1;
+            // multiply all dimension
+            for (std::list<int>::iterator it = dimension_list_.begin();
+                it != dimension_list_.end(); it++) {
+                array_size *= *it;
+            }
+            if (array_size <= 1) {
+                DispErr("array size cannot be less than or 1 ");
+                DispErr("in DataType::SetArraySize()");
+            } else {
+                array_size_ = array_size;
+            }
+        }
+        return array_size_;
+    }
+
+    // DataTypeTable class
+
+    DataTypeTable::DataTypeTable() {
+        int cur = U8;
+        // Add primitive types into data type table's map
+        for (cur = U8; cur <= C32; cur++) {
+            TypeSpecifier type = (TypeSpecifier)cur;
+            map_[apus::ToString[type]] = 
+                std::make_shared<DataType>(type);
+        }
+    }
+
+    DataTypeTable::~DataTypeTable() {
+    }
+
+    void DataTypeTable::Insert(const std::string& name, DataType* elem) {
+        DataTypePtr elem_ptr(elem);
+        map_[name] = elem_ptr;
+    }
+
+    void DataTypeTable::Insert(const std::string& name, DataTypePtr elem) {
+        map_[name] = elem;
+    }
+
+    DataTypePtr DataTypeTable::Find(const std::string& name) {
+        DataTypeMap::iterator it = map_.find(name);
+        if (it != map_.end()) {
+            return it->second;
+        }
+        return nullptr;
+    }
+
+    DataTypePtr DataTypeTable::Find(TypeSpecifier type) {
+        DataTypeMap::iterator it = map_.find(apus::ToString[type]);
+        if (it != map_.end()) {
+            return it->second;
+        }
+        return nullptr;
+    }
+}
+

--- a/test/vm/data_type_table_unit_test.cpp
+++ b/test/vm/data_type_table_unit_test.cpp
@@ -1,0 +1,127 @@
+#include "gtest/gtest.h"
+#include "common/common.h"
+#include "vm/data_type_table.h"
+using namespace apus;
+
+std::shared_ptr<DataTypeTable> g_dtt = std::make_shared<DataTypeTable>();
+
+TEST(data_type_test, initialization) {
+    ASSERT_TRUE(g_dtt != NULL);
+    g_dtt->SetPrimitiveTypes();
+   
+    // Check primitive types to be in data type table
+    for (int i = U8; i <= C32; i++) {
+        ASSERT_TRUE(g_dtt->Find((TypeSpecifier)i) != NULL);
+    }
+}
+
+// struct struct1 {
+//     S32 integer1
+//     S16 integer2
+//     F32 float1
+// }
+TEST(data_type_test, simple_struct_test) {
+    
+    DataType* struct1 = new DataType(STRUCT);    
+    struct1->Insert("integer1", g_dtt->Find(U8));
+    struct1->Insert("integer2", g_dtt->Find(S16));
+    struct1->Insert("float1", g_dtt->Find(F32));
+    EXPECT_TRUE(struct1->HasChild());
+    
+    g_dtt->Insert("struct1", struct1);
+}
+
+// struct child_struct {
+//     U64 unsigned1
+//     U32 unsigned2
+//     C16 char1
+// }
+//
+// struct parent_struct {
+//     C8 char2
+//     struct child_struct child1
+// }
+TEST(data_type_test, struct_in_struct_test) {
+    
+    DataType* childStruct = new DataType(STRUCT);
+    childStruct->Insert("unsigned1", g_dtt->Find(U64));
+    childStruct->Insert("unsigned2", g_dtt->Find(U32));
+    childStruct->Insert("char1", g_dtt->Find(C16));
+    EXPECT_TRUE(childStruct->HasChild());
+    
+    DataType* parentStruct = new DataType(STRUCT);
+    parentStruct->Insert("char2", g_dtt->Find(C8));
+    parentStruct->Insert("child_struct", childStruct);
+    EXPECT_TRUE(parentStruct->HasChild());
+    
+    g_dtt->Insert("parent_struct", parentStruct);
+}
+
+// struct struct2 {
+//     U64 unsigned1
+//     U32 unsigned2
+//     C16 char1
+// }
+TEST(data_type_test, Find_test) {
+    
+    DataType* struct2 = new DataType(STRUCT);
+    struct2->Insert("unsigned1", g_dtt->Find(U64));
+    struct2->Insert("unsigned2", g_dtt->Find(U32));
+    struct2->Insert("char1", g_dtt->Find(C16));
+    EXPECT_TRUE(struct2->HasChild());
+    
+    // things which can be found in this data type
+    EXPECT_TRUE(struct2->Find("unsigned1") != NULL);
+    EXPECT_TRUE(struct2->Find("unsigned2") != NULL);
+    EXPECT_TRUE(struct2->Find("char1") != NULL);
+    // things which cannot be found in this data type
+    EXPECT_TRUE(struct2->Find("not_exist") == NULL);
+    
+    g_dtt->Insert("struct2", struct2);
+}
+
+// struct struct_with_array {
+//     U16[3][4] array1
+// }
+TEST(data_type_test, array_test) {
+    
+    ArrayDataType* array = new ArrayDataType(ARRAY);
+    array->AddDimension(4);
+    array->AddDimension(3);
+    array->SetElement(g_dtt->Find(U16));
+    EXPECT_EQ(array->GetArraySize(), 3*4);
+    EXPECT_EQ(array->GetByteSize(), 3*4*2);
+    
+    DataType* struct_with_array = new DataType(STRUCT);
+    struct_with_array->Insert("array1", array);
+    
+    g_dtt->Insert("struct_with_array", struct_with_array);
+}
+
+// struct struct_with_struct_array {
+//     struct struct1[2] struct_array
+// }
+TEST(data_type_test, struct_array_test) {
+    
+    // copy "struct1" structure from data type table
+    ArrayDataType* childStruct = new ArrayDataType(STRUCT_ARRAY);
+    childStruct->AddDimension(2);
+    childStruct->SetElement(g_dtt->Find("struct1"));
+    
+    DataType* struct_with_struct_array = new DataType(STRUCT);
+    struct_with_struct_array->Insert("struct_array", childStruct);
+    EXPECT_TRUE(struct_with_struct_array->HasChild());
+    
+    g_dtt->Insert("struct_with_struct_array", struct_with_struct_array);
+}
+
+TEST(data_type_table_test, Find_test) {
+    
+    EXPECT_TRUE(g_dtt->Find("struct1") != NULL);
+    EXPECT_TRUE(g_dtt->Find("parent_struct") != NULL);
+    EXPECT_TRUE(g_dtt->Find("struct2") != NULL);
+    EXPECT_TRUE(g_dtt->Find("struct_with_array") != NULL);
+    EXPECT_TRUE(g_dtt->Find("struct_with_struct_array") != NULL);
+
+
+}


### PR DESCRIPTION
각 커밋에 대한 간략 설명
1. 열거형 타입에 필요한 타입들 추가
2. 열거형 타입을 쉽게 string으로 출력해주기 위해서 string 배열 추가
   (예를 들어, U8을 쓸 때 "U8"로 사용할수 있게 만들어줄 요량으로 작성)
3. 에러 메시지 루틴 추가 (ERROR_MSG 플래그가 true일 떄만 error msg를 출력)
4. DataType 및 DataTypeTable 클래스 작성
5. ArrayDataType 클래스 작성
6. 위에서 작성한 클래스들에 대해 유닛 테스트 작성
