### PR TITLE
parser: grammar_fix-v1

### DIFF
--- a/src/apus.l
+++ b/src/apus.l
@@ -108,8 +108,20 @@
     return ID;
 }
 
-'([^'\n|\\'])'     { return CHAR_LITERAL; }
-\"([^"\n]|\\\")*\" { return STRING_LITERAL; }
+'([^'\n|\\'])' {
+    yylval.char_val = yytext[1];
+    return CHAR_LITERAL;
+}
+
+\"([^"\n]|\\\")*\" {
+    char* tmp = (char*)malloc(yyleng-2);
+    yylval.str_val = (char*)malloc(yyleng-2);
+    yytext[yyleng-1] = '\0';
+    sscanf(yytext, "\"%s", tmp);
+    sprintf(yylval.str_val, "%s", tmp);
+    free(tmp);
+    return STRING_LITERAL;
+}
 
 [#]+.*[\n] ;
 [\t ]+ ;

--- a/src/apus.l
+++ b/src/apus.l
@@ -123,6 +123,36 @@
     return STRING_LITERAL;
 }
 
+[0][b][0-1]* {
+    int num_tmp;
+    char* tmp = (char*)malloc(yyleng);
+    sscanf(yytext, "0b%s", tmp);
+    num_tmp = strtol(tmp, NULL, 2);
+    yylval.int_val = num_tmp;
+    free(tmp);
+    return BINARY_LITERAL;
+}
+
+[0][0-8]* {
+    int num_tmp;
+    char* tmp = (char*)malloc(yyleng);
+    sscanf(yytext, "0%s", tmp);
+    num_tmp = strtol(tmp, NULL, 8);
+    yylval.int_val = num_tmp;
+    free(tmp);
+    return OCTA_LITERAL;
+}
+
+[0][x][0-9a-fA-F] {
+    int num_tmp;
+    char* tmp = (char*)malloc(yyleng);
+    sscanf(yytext, "0x%s", tmp);
+    num_tmp = strtol(tmp, NULL, 16);
+    yylval.int_val = num_tmp;
+    free(tmp);
+    return HEXA_LITERAL;
+}
+
 [#]+.*[\n] ;
 [\t ]+ ;
 %%

--- a/src/apus.l
+++ b/src/apus.l
@@ -10,23 +10,23 @@
 %option yylineno
 
 %%
-"u8"    { return U8; }
-"u16"   { return U16; }
-"u32"   { return U32; }
-"u64"   { return U64; }
-"s8"    { return S8; }
-"s16"   { return S16; }
-"s32"   { return S32; }
-"s64"   { return S64; }
-"f32"   { return F32; }
-"f64"   { return F64; }
-"c8"    { return C8; }
-"c16"   { return C16; }
-"c32"   { return C32; }
-"str"   { return STR; }
-"str8"  { return STR8; }
-"str16" { return STR16; }
-"str32" { return STR32; }
+"u8"    { return UINT8; }
+"u16"   { return UINT16; }
+"u32"   { return UINT32; }
+"u64"   { return UINT64; }
+"s8"    { return SINT8; }
+"s16"   { return SINT16; }
+"s32"   { return SINT32; }
+"s64"   { return SINT64; }
+"f32"   { return FLOAT32; }
+"f64"   { return FLOAT64; }
+"c8"    { return CHAR8; }
+"c16"   { return CHAR16; }
+"c32"   { return CHAR32; }
+"str"   { return STRING; }
+"str8"  { return STRING8; }
+"str16" { return STRING16; }
+"str32" { return STRING32; }
 "var"   { return VAR; }
 
 "include"  { return INCLUDE; }

--- a/src/apus.y
+++ b/src/apus.y
@@ -180,6 +180,7 @@ primary_expression :
 variable_expression :
     ID
     | ID dimension_array
+    | variable_expression DOT variable_expression
     ;
 comma_line_opt :
     COMMA line_opt

--- a/src/apus.y
+++ b/src/apus.y
@@ -131,7 +131,17 @@ expression_opt :
     | expression
     ;
 expression :
-    expression assign_operator expression
+    expression ASSIGN expression
+    | expression ADDASSIGN expression
+    | expression SUBASSIGN expression
+    | expression MULASSIGN expression
+    | expression DIVASSIGN expression
+    | expression MODASSIGN expression
+    | expression ORASSIGN expression
+    | expression XORASSIGN expression
+    | expression ANDASSIGN expression
+    | expression LSASSIGN expression
+    | expression RSASSIGN expression
     | expression LOR expression
     | expression LAND expression
     | expression OR expression
@@ -195,12 +205,6 @@ type_specifier :
     | F32 | F64
     | C8 | C16 | C32
     | STR | STR8 | STR16 | STR32
-    ;
-assign_operator :
-    ASSIGN | ADDASSIGN | SUBASSIGN
-    | MULASSIGN | DIVASSIGN | MODASSIGN
-    | ORASSIGN | ANDASSIGN | XORASSIGN
-    | LSASSIGN | RSASSIGN
     ;
 action_declaration : 
     block_statement

--- a/src/apus.y
+++ b/src/apus.y
@@ -27,6 +27,7 @@ extern int yyerror(apus::ParserContext* pctx, char const *str);
 %token<char_val> CHAR_LITERAL
 %token<str_val> STRING_LITERAL
 %token<str_val> ID
+%token<int_val> BINARY_LITERAL OCTA_LITERAL HEXA_LITERAL
 
 %token<int_val> U8 U16 U32 U64
 %token<int_val> S8 S16 S32 S64

--- a/src/apus.y
+++ b/src/apus.y
@@ -29,11 +29,11 @@ extern int yyerror(apus::ParserContext* pctx, char const *str);
 %token<str_val> ID
 %token<int_val> BINARY_LITERAL OCTA_LITERAL HEXA_LITERAL
 
-%token<int_val> U8 U16 U32 U64
-%token<int_val> S8 S16 S32 S64
-%token<double_val> F32 F64
-%token<char_val> C8 C16 C32
-%token<str_val> STR STR8 STR16 STR32
+%token<int_val> UINT8 UINT16 UINT32 UINT64
+%token<int_val> SINT8 SINT16 SINT32 SINT64
+%token<double_val> FLOAT32 FLOAT64
+%token<char_val> CHAR8 CHAR16 CHAR32
+%token<str_val> STRING STRING8 STRING16 STRING32
 %token STRUCT CONST UNION
 
 %token L_BRACE R_BRACE L_CASE R_CASE OPEN CLOSE
@@ -202,11 +202,11 @@ semi_start :
     line_opt SEMI line_opt
     ;
 type_specifier :
-    U8 | U16 | U32 | U64
-    | S8 | S16 | S32 | S64
-    | F32 | F64
-    | C8 | C16 | C32
-    | STR | STR8 | STR16 | STR32
+    UINT8 | UINT16 | UINT32 | UINT64
+    | SINT8 | SINT16 | SINT32 | SINT64
+    | FLOAT32 | FLOAT64
+    | CHAR8 | CHAR16 | CHAR32
+    | STRING | STRING8 | STRING16 | STRING32
     ;
 action_declaration : 
     block_statement


### PR DESCRIPTION
수정된 문법
- lex파일에서 char, string 따옴표 제거 후, return하도록 수정
- assign_operator를 expression으로 이동 (%left, %right의 우선순위를 위함)
- dot expression 추가
- 16진수, 8진수 2진수 표현 추가
- common.h의 이름 중복으로, 토큰 이름 제거.
