### PR TITLE
Value: CharacterValue added with updated Promote funcs -v4

### DIFF
--- a/include/ast/value/character_value.h
+++ b/include/ast/value/character_value.h
@@ -1,0 +1,49 @@
+#ifndef CHARACTER_VALUE_H_
+#define CHARACTER_VALUE_H_
+
+#include <memory>
+#include "value.h"
+#include "common/common.h"
+
+namespace apus {
+
+    class CharacterValue : public Value {
+    public:
+
+        static std::shared_ptr<CharacterValue> Create(TypeSpecifier type , int32_t value);
+
+        virtual ~CharacterValue() {}
+
+        virtual std::shared_ptr<Value> Copy() const {
+            return CharacterValue::Create(this->getType(), getCharValue());
+        }
+
+        virtual std::shared_ptr<Value> Promote(
+                const std::shared_ptr<Value> another) const override;
+
+        virtual std::shared_ptr<Value> OperateBinary(
+                const Expression::Type expression_type,
+                const std::shared_ptr<Value>& right) const override;
+
+        virtual std::shared_ptr<Value> OperateUnary(
+                const Expression::Type expression_type) const override;
+
+        int32_t getCharValue() const {
+            return *((int32_t *)value_.get());
+        }
+
+    protected:
+
+        CharacterValue(TypeSpecifier type, int32_t value)
+                : Value(type, std::make_shared<int32_t>(value)) {
+        }
+
+        CharacterValue(TypeSpecifier type, std::shared_ptr<void> value_ptr)
+                : Value(type, value_ptr) {
+        }
+
+    };
+
+}
+
+#endif

--- a/src/ast/value/character_value.cpp
+++ b/src/ast/value/character_value.cpp
@@ -1,0 +1,95 @@
+#include "ast/value/character_value.h"
+#include "ast/value/float_value.h"
+
+namespace apus {
+
+    std::shared_ptr<CharacterValue> CharacterValue::Create(TypeSpecifier type, int32_t value) {
+
+        if (type == C8 || type == C16 || type == C32) {
+            return std::shared_ptr<CharacterValue>(new CharacterValue(type, value));
+        }
+
+        return nullptr;
+    }
+
+    std::shared_ptr<Value> CharacterValue::Promote(
+            const std::shared_ptr<Value> another) const {
+
+        const TypeSpecifier another_type = another->getType();
+
+        if (type_ == another_type) {
+            return this->Copy();
+        }
+
+        switch (another_type) {
+
+            case C8:
+            case C16:
+            case C32: {
+                TypeSpecifier return_type = getSize() > another->getSize()
+                                            ? getType()
+                                            : another_type;
+
+                return CharacterValue::Create(return_type, this->getCharValue());
+            }
+
+            default:
+                return nullptr;
+
+        }
+
+    }
+
+    std::shared_ptr<Value> CharacterValue::OperateBinary(
+            const Expression::Type expression_type,
+            const std::shared_ptr<Value> &right_promoted) const {
+
+        std::shared_ptr<Value> result = nullptr;
+
+        if (right_promoted->getType() == this->getType()) {
+
+            std::shared_ptr<CharacterValue> right_dynamic = std::dynamic_pointer_cast<CharacterValue>(right_promoted);
+
+            int32_t left_value = this->getCharValue();
+            int32_t right_value = right_dynamic->getCharValue();
+
+            int32_t result_value = 0;
+
+            switch (expression_type) {
+
+                case Expression::Type::EXP_EQL :
+                    result_value = left_value == right_value;
+                    break;
+                case Expression::Type::EXP_NEQ :
+                    result_value = left_value != right_value;
+                    break;
+                case Expression::Type::EXP_LSS :
+                    result_value = left_value < right_value;
+                    break;
+                case Expression::Type::EXP_GTR :
+                    result_value = left_value > right_value;
+                    break;
+                case Expression::Type::EXP_LEQ :
+                    result_value = left_value <= right_value;
+                    break;
+                case Expression::Type::EXP_GEQ :
+                    result_value = left_value >= right_value;
+                    break;
+
+                default:
+                    return nullptr;
+            }
+
+            result = CharacterValue::Create(this->getType(), result_value);
+        }
+
+        return result;
+    }
+
+    std::shared_ptr<Value> CharacterValue::OperateUnary(
+            const Expression::Type expression_type) const {
+
+        return nullptr;
+    }
+
+}

--- a/src/ast/value/float_value.cpp
+++ b/src/ast/value/float_value.cpp
@@ -27,31 +27,27 @@ namespace apus {
 
         switch (another_type) {
 
-            // case 2. Same class but size
             case F32:
             case F64: {
-                TypeSpecifier type = getType() > another_type
+                TypeSpecifier type = getSize() > another->getSize()
                                      ? getType()
                                      : another_type;
 
                 return FloatValue::Create(type, this->getFloatValue());
             }
 
-            // case 3. Different class
             case S8:
             case S16:
             case S32:
             case S64: {
-                
-                // case 3.1 SignedIntValue
+
                 return this->Copy();
 
             }
             default:
                 return nullptr;
         }
-
-        return nullptr;
+        
     }
 
     ValuePtr FloatValue::OperateBinary(

--- a/src/ast/value/signed_int_value.cpp
+++ b/src/ast/value/signed_int_value.cpp
@@ -1,8 +1,9 @@
 #include "ast/value/signed_int_value.h"
+#include "ast/value/float_value.h"
+#include "ast/value/character_value.h"
+
 #include "ast/expression.h"
 #include "common/common.h"
-
-#include "ast/value/float_value.h"
 
 namespace apus {
 
@@ -30,12 +31,11 @@ namespace apus {
 
         switch (another_type) {
 
-            // case 2. Same class but size
             case S8:
             case S16:
             case S32:
             case S64: {
-                TypeSpecifier return_type = getType() > another_type ? getType() : another_type;
+                TypeSpecifier return_type = getSize() > another->getSize() ? getType() : another_type;
                 return SignedIntValue::Create(return_type, this->getIntValue());
             }
 

--- a/test/ast/ast_test.cpp
+++ b/test/ast/ast_test.cpp
@@ -8,6 +8,7 @@
 
 #include "ast/value/signed_int_value.h"
 #include "ast/value/float_value.h"
+#include "ast/value/character_value.h"
 
 #include "vm/context.h"
 
@@ -90,30 +91,6 @@ TEST (ASTTest, Expression_ASMD) {
         std::shared_ptr<FloatValue> result = std::dynamic_pointer_cast<FloatValue>(div_expr->Evaluate(ctx));
 
         EXPECT_EQ( (2 * 3.5 / 3) , result->getFloatValue());
-    }
-
-    // 2 * 3.5 (S16 * F32)
-    {
-        std::shared_ptr<Expression> _2 = std::make_shared<ValueExpression>(SignedIntValue::Create(S16, 2));
-        std::shared_ptr<Expression> _3_5 = std::make_shared<ValueExpression>(FloatValue::Create(F32, 3.5));
-
-        std::shared_ptr<Expression> mul_expr = std::make_shared<BinaryExpression>(Expression::EXP_MUL, _2, _3_5);
-
-        std::shared_ptr<FloatValue> result = std::dynamic_pointer_cast<FloatValue>(mul_expr->Evaluate(ctx));
-
-        EXPECT_EQ( (2 * 3.5) , result->getFloatValue());
-    }
-
-    // 2 * 3.5 (S64 * F32)
-    {
-        std::shared_ptr<Expression> _2 = std::make_shared<ValueExpression>(SignedIntValue::Create(S64, 2));
-        std::shared_ptr<Expression> _3_5 = std::make_shared<ValueExpression>(FloatValue::Create(F32, 3.5));
-
-        std::shared_ptr<Expression> mul_expr = std::make_shared<BinaryExpression>(Expression::EXP_MUL, _2, _3_5);
-
-        std::shared_ptr<FloatValue> result = std::dynamic_pointer_cast<FloatValue>(mul_expr->Evaluate(ctx));
-
-        EXPECT_EQ( (2 * 3.5) , result->getFloatValue());
     }
 
 }
@@ -202,5 +179,48 @@ TEST (ASTTest, Expression_Float_EQL_Compare) {
     // a <= b
     result = std::dynamic_pointer_cast<FloatValue>(leq_expr->Evaluate(ctx));
     EXPECT_TRUE(result->getFloatValue());
+
+}
+
+TEST (ASTTest, Expression_Promote) {
+
+    // 2 * 3.5 (S16 * F32)
+    {
+        std::shared_ptr<Expression> _2 = std::make_shared<ValueExpression>(SignedIntValue::Create(S16, 2));
+        std::shared_ptr<Expression> _3_5 = std::make_shared<ValueExpression>(FloatValue::Create(F32, 3.5));
+
+        std::shared_ptr<Expression> mul_expr = std::make_shared<BinaryExpression>(Expression::EXP_MUL, _2, _3_5);
+
+        std::shared_ptr<FloatValue> result = std::dynamic_pointer_cast<FloatValue>(mul_expr->Evaluate(ctx));
+
+        EXPECT_EQ( (2 * 3.5) , result->getFloatValue());
+        EXPECT_EQ(F32 , result->getType());
+    }
+
+    // 2 * 3.5 (S64 * F32)
+    {
+        std::shared_ptr<Expression> _2 = std::make_shared<ValueExpression>(SignedIntValue::Create(S64, 2));
+        std::shared_ptr<Expression> _3_5 = std::make_shared<ValueExpression>(FloatValue::Create(F32, 3.5));
+
+        std::shared_ptr<Expression> mul_expr = std::make_shared<BinaryExpression>(Expression::EXP_MUL, _2, _3_5);
+
+        std::shared_ptr<FloatValue> result = std::dynamic_pointer_cast<FloatValue>(mul_expr->Evaluate(ctx));
+
+        EXPECT_EQ( (2 * 3.5) , result->getFloatValue());
+        EXPECT_EQ(F32 , result->getType());
+    }
+
+    // 'A' < 'B' (C8 + C16)
+    {
+        std::shared_ptr<Expression> _a = std::make_shared<ValueExpression>(CharacterValue::Create(C8, 'A'));
+        std::shared_ptr<Expression> _b = std::make_shared<ValueExpression>(CharacterValue::Create(C16, 'B'));
+
+        std::shared_ptr<Expression> lss_expr = std::make_shared<BinaryExpression>(Expression::EXP_LSS, _a, _b);
+
+        std::shared_ptr<CharacterValue> result = std::dynamic_pointer_cast<CharacterValue>(lss_expr->Evaluate(ctx));
+
+        EXPECT_TRUE(result->getCharValue());
+        EXPECT_EQ(C16 , result->getType());
+    }
 
 }


### PR DESCRIPTION
1. Promote 로직을 #76 에서 제안한 것(에서 Character 타입 분리 추가) 처럼 수정했습니다.
2. CharacterValue를 추가했습니다.
3. 관련 테스트 코드를 추가했습니다.
- Character타입을 숫자타입과 분리시키고, 비교 연산만 가능하게 연산을 추려냈습니다.
  ++ 커밋 메세지 수정하고, 테스트 코드 수정했습니다.
