### PR TITLE
Ast: Statement logic fix

### DIFF
--- a/include/ast/value/value.h
+++ b/include/ast/value/value.h
@@ -36,6 +36,8 @@ namespace apus {
         virtual ValuePtr OperateUnary(
                 const Expression::Type expression_type) const = 0;
 
+        static bool IsTrue(std::shared_ptr<Value> value);
+
     protected:
 
         Value(TypeSpecifier type, std::shared_ptr<void> value)

--- a/src/ast/expression.cpp
+++ b/src/ast/expression.cpp
@@ -26,10 +26,12 @@ namespace apus {
 
 
     BinaryExpression::BinaryExpression(Type type, Expression* leftExpression,
-            Expression* rightExpression) {
-        std::shared_ptr<Expression> left(leftExpression);
-        std::shared_ptr<Expression> right(rightExpression);
-        BinaryExpression(type, left, right);
+            Expression* rightExpression)
+    
+        : BinaryExpression(type,
+                           std::shared_ptr<Expression>(leftExpression),
+                           std::shared_ptr<Expression>(rightExpression)) {
+
     }
 
     BinaryExpression::~BinaryExpression() {
@@ -73,11 +75,9 @@ namespace apus {
 
     }
 
-    UnaryExpression::UnaryExpression(Type type, Expression* expression) {
+    UnaryExpression::UnaryExpression(Type type, Expression* expression)
 
-        std::shared_ptr<Expression> shared_expr(expression);
-        UnaryExpression(type, shared_expr);
-
+        : UnaryExpression(type, std::shared_ptr<Expression>(expression)) {
     }
 
     UnaryExpression::~UnaryExpression() {
@@ -100,8 +100,8 @@ namespace apus {
 
     }
 
-    ValueExpression::ValueExpression(Value *value) {
-        ValueExpression(std::shared_ptr<Value>(value));
+    ValueExpression::ValueExpression(Value *value)
+        : ValueExpression(std::shared_ptr<Value>(value)) {
     }
 
     std::shared_ptr<Value> ValueExpression::Evaluate(Context &context) {
@@ -114,8 +114,8 @@ namespace apus {
         : Expression(EXP_VARIABLE), name_(name) {
     }
 
-    VariableExpression::VariableExpression(char *name) {
-        VariableExpression(std::string(name));
+    VariableExpression::VariableExpression(char *name)
+        : VariableExpression(std::string(name)) {
     }
 
     VariableExpression::~VariableExpression() {
@@ -140,8 +140,8 @@ namespace apus {
     }
 
     AssignExpression::AssignExpression(Type type, char* name,
-                                       Expression* expression) {
-        AssignExpression(type, std::string(name), std::shared_ptr<Expression>(expression));
+                                       Expression* expression)
+        : AssignExpression(type, std::string(name), std::shared_ptr<Expression>(expression)) {
     }
 
     AssignExpression::~AssignExpression() {
@@ -182,8 +182,8 @@ namespace apus {
 
     }
 
-    MemberExpression::MemberExpression(char* parent_name, char* child_name) {
-        MemberExpression(std::string(parent_name), std::string(child_name));
+    MemberExpression::MemberExpression(char* parent_name, char* child_name)
+        : MemberExpression(std::string(parent_name), std::string(child_name)) {
     }
 
     MemberExpression::~MemberExpression() {

--- a/src/ast/statement/expression_statement.cpp
+++ b/src/ast/statement/expression_statement.cpp
@@ -20,6 +20,8 @@ namespace apus {
     }
 
     void ExpressionStatement::Execute(Context& context) {
-        expression_->Evaluate(context);
+        if (expression_) {
+            expression_->Evaluate(context);
+        }
     }
 }

--- a/src/ast/statement/if_statement.cpp
+++ b/src/ast/statement/if_statement.cpp
@@ -1,6 +1,9 @@
 #include "ast/statement/if_statement.h"
 #include "ast/statement/block.h"
 #include "ast/expression.h"
+
+#include "ast/value/value.h"
+
 #include "vm/context.h"
 
 namespace apus {
@@ -25,11 +28,23 @@ namespace apus {
     }
 
     void IfStatement::Execute(Context& context) {
-        if( condition_->Evaluate(context) ) {
-            true_block_->Execute(context);
-        }
-        else {
-            false_block_->Execute(context);
+
+        if (condition_) {
+
+            if (Value::IsTrue(condition_->Evaluate(context))) {
+
+                if (true_block_) {
+                    true_block_->Execute(context);
+                }
+            }
+
+            else {
+
+                if (false_block_) {
+                    false_block_->Execute(context);
+                }
+            }
+
         }
     }
 

--- a/src/ast/statement/jump_statement.cpp
+++ b/src/ast/statement/jump_statement.cpp
@@ -26,6 +26,11 @@ namespace apus {
     }
 
     void ReturnStatement::Execute(Context& context) {
+
+        if (expression_) {
+            expression_->Evaluate(context);
+        }
+
         context.SetReturn(true);
     }
 
@@ -39,6 +44,11 @@ namespace apus {
     }
 
     void ExitStatement::Execute(Context &context) {
+
+        if (expression_) {
+            expression_->Evaluate(context);
+        }
+
         context.SetExit(true);
     }
 

--- a/src/ast/statement/jump_statement.cpp
+++ b/src/ast/statement/jump_statement.cpp
@@ -12,7 +12,8 @@ namespace apus {
         context.SetContinue(true);
     }
 
-    ReturnStatement::ReturnStatement() : expression_(nullptr) {
+    ReturnStatement::ReturnStatement()
+        : expression_(nullptr) {
 
     }
 
@@ -21,8 +22,8 @@ namespace apus {
 
     }
 
-    ReturnStatement::ReturnStatement(Expression *expression) {
-        ReturnStatement( ExprPtr(expression) );
+    ReturnStatement::ReturnStatement(Expression *expression)
+        : ReturnStatement( ExprPtr(expression) ) {
     }
 
     void ReturnStatement::Execute(Context& context) {
@@ -39,8 +40,8 @@ namespace apus {
 
     }
 
-    ExitStatement::ExitStatement(Expression *expression) {
-        ExitStatement( ExprPtr(expression) );
+    ExitStatement::ExitStatement(Expression *expression)
+        : ExitStatement( ExprPtr(expression) ) {
     }
 
     void ExitStatement::Execute(Context &context) {

--- a/src/ast/value/value.cpp
+++ b/src/ast/value/value.cpp
@@ -1,0 +1,41 @@
+#include "ast/value/value.h"
+
+#include "ast/value/signed_int_value.h"
+#include "ast/value/float_value.h"
+
+namespace apus {
+
+    bool Value::IsTrue(std::shared_ptr<Value> value) {
+
+        switch (value->getType()) {
+            case S8:
+            case S16:
+            case S32:
+            case S64:
+                return (std::dynamic_pointer_cast<SignedIntValue>(value)->getIntValue() != 0);
+
+            case U8:
+            case U16:
+            case U32:
+            case U64:
+                return false;
+
+            case C8:
+            case C16:
+            case C32:
+                return false;
+
+            case F32:
+            case F64:
+                return (std::dynamic_pointer_cast<FloatValue>(value)->getFloatValue() != 0);
+
+            case STR8:
+            case STR16:
+            case STR32:
+
+            default:
+                return false;
+        }
+    }
+
+}

--- a/test/ast/ast_test.cpp
+++ b/test/ast/ast_test.cpp
@@ -222,5 +222,21 @@ TEST (ASTTest, Expression_Promote) {
         EXPECT_TRUE(result->getCharValue());
         EXPECT_EQ(C16 , result->getType());
     }
+}
+TEST (ASTTest, IsTrue) {
+
+    bool result = false;
+
+    result = Value::IsTrue(SignedIntValue::Create(S32, 123));
+    EXPECT_TRUE(result);
+
+    result = Value::IsTrue(SignedIntValue::Create(S32, 0));
+    EXPECT_FALSE(result);
+
+    result = Value::IsTrue(FloatValue::Create(F32, 123.4));
+    EXPECT_TRUE(result);
+
+    result = Value::IsTrue(FloatValue::Create(F32, 0));
+    EXPECT_FALSE(result);
 
 }


### PR DESCRIPTION
1. ForStatement나 IfStatement에서 Expression을 사용할때, Value와 비교해 주지 않아서 조건문이 제대로 판별되지 않던 문제를 Value::IsTrue 멤버 함수를 사용해서 비교해주는 것으로 해결했습니다.
2. Statement의 인자들에 nullptr이 들어가는 경우가 있을 수 있기 때문에, 실행할 때 nullptr인지 아닌지 확인하는 루틴을 추가했습니다. 
