### PR TITLE
Value : Added EXP_ASSIGN case on OperateBinary

### DIFF
--- a/src/ast/value/character_value.cpp
+++ b/src/ast/value/character_value.cpp
@@ -57,6 +57,10 @@ namespace apus {
 
             switch (expression_type) {
 
+                case Expression::Type::EXP_ASSIGN :
+                    result_value = right_value;
+                    break;
+
                 case Expression::Type::EXP_EQL :
                     result_value = left_value == right_value;
                     break;

--- a/src/ast/value/float_value.cpp
+++ b/src/ast/value/float_value.cpp
@@ -95,6 +95,10 @@ namespace apus {
                     result_value = (left_value > right_value) || this->NearlyEqual(right_value);
                     break;
 
+                case Expression::Type::EXP_ASSIGN :
+                    result_value = right_value;
+                    break;
+
                 case Expression::Type::EXP_LSHIFT :
                 case Expression::Type::EXP_LSASSIGN :
                     return nullptr;

--- a/src/ast/value/signed_int_value.cpp
+++ b/src/ast/value/signed_int_value.cpp
@@ -95,6 +95,10 @@ namespace apus {
                     result_value = left_value >= right_value;
                     break;
 
+                case Expression::Type::EXP_ASSIGN :
+                    result_value = right_value;
+                    break;
+                    
                 case Expression::Type::EXP_LSHIFT :
                 case Expression::Type::EXP_LSASSIGN :
                     result_value = left_value << right_value;


### PR DESCRIPTION
AssignExpression에서 단순 대입연산 구현시 EXP_ASSIGN 케이스에 대한 연산이 없으면 정상 동작 하지 않았습니다.
