### PR TITLE
parser: merge_expr-v3

### DIFF
--- a/src/apus.l
+++ b/src/apus.l
@@ -114,12 +114,9 @@
 }
 
 \"([^"\n]|\\\")*\" {
-    char* tmp = (char*)malloc(yyleng-1);
     yylval.str_val = (char*)malloc(yyleng-1);
-    yytext[yyleng-1] = '\0';
-    sscanf(yytext, "\"%s", tmp);
-    sprintf(yylval.str_val, "%s", tmp);
-    free(tmp);
+    memcpy(yylval.str_val, yytext+1, yyleng-2);
+    yylval.str_val[yyleng-2] = '\0';
     return STRING_LITERAL;
 }
 

--- a/src/apus.y
+++ b/src/apus.y
@@ -14,13 +14,37 @@ extern int yyerror(apus::ParserContext* pctx, char const *str);
 }
 
 %code requires {
-    #include "common/common.h"
+    #include <memory>
+    #include <list>
+
+    #include "vm/virtual_machine.h"
+
+    #include "ast/expression.h"
+
+    #include "ast/value/value.h"
+    #include "ast/value/signed_int_value.h"
+    #include "ast/value/unsigned_int_value.h"
+    #include "ast/value/float_value.h"
+    #include "ast/value/character_value.h"
+    #include "ast/value/string_value.h"
+
+    using namespace std;
+    using namespace apus;
+
 }
 %union {
     int64_t int_val;
     double double_val;
     int char_val;
     char* str_val;
+
+    TypeSpecifier type_spec;
+
+    Expression* expr;
+    Expression::Type expr_type;
+
+    Value* value;
+
 }
 %token<int_val> INT_LITERAL
 %token<double_val> DOUBLE_LITERAL
@@ -29,11 +53,11 @@ extern int yyerror(apus::ParserContext* pctx, char const *str);
 %token<str_val> ID
 %token<int_val> BINARY_LITERAL OCTA_LITERAL HEXA_LITERAL
 
-%token<int_val> UINT8 UINT16 UINT32 UINT64
-%token<int_val> SINT8 SINT16 SINT32 SINT64
-%token<double_val> FLOAT32 FLOAT64
-%token<char_val> CHAR8 CHAR16 CHAR32
-%token<str_val> STRING STRING8 STRING16 STRING32
+%token<type_spec> UINT8 UINT16 UINT32 UINT64
+%token<type_spec> SINT8 SINT16 SINT32 SINT64
+%token<type_spec> FLOAT32 FLOAT64
+%token<type_spec> CHAR8 CHAR16 CHAR32
+%token<type_spec> STRING STRING8 STRING16 STRING32
 %token STRUCT CONST UNION
 
 %token L_BRACE R_BRACE L_CASE R_CASE OPEN CLOSE
@@ -52,6 +76,11 @@ extern int yyerror(apus::ParserContext* pctx, char const *str);
 %left ADD SUB
 %left MUL DIV MOD
 %right NOT REVERSE
+
+%type<expr> expression expression_opt unary_expression primary_expression variable_expression
+%type<expr> init_expression
+
+%type<type_spec> type_specifier
 
 %%
 program :
@@ -143,42 +172,42 @@ expression :
     | variable_expression ANDASSIGN expression
     | variable_expression LSASSIGN expression
     | variable_expression RSASSIGN expression
-    | expression LOR expression
-    | expression LAND expression
-    | expression OR expression
-    | expression XOR expression
-    | expression AND expression
-    | expression EQL expression
-    | expression NEQ expression
-    | expression LSS expression
-    | expression GTR expression
-    | expression LEQ expression
-    | expression GEQ expression
-    | expression LSHIFT expression
-    | expression RSHIFT expression
-    | expression ADD expression
-    | expression SUB expression
-    | expression MUL expression
-    | expression DIV expression
-    | expression MOD expression
+    | expression LOR expression { $$ = new BinaryExpression(Expression::EXP_LOR, $1, $3); }
+    | expression LAND expression { $$ = new BinaryExpression(Expression::EXP_LAND, $1, $3); }
+    | expression OR expression { $$ = new BinaryExpression(Expression::EXP_OR, $1, $3); }
+    | expression XOR expression { $$ = new BinaryExpression(Expression::EXP_XOR, $1, $3); }
+    | expression AND expression { $$ = new BinaryExpression(Expression::EXP_AND, $1, $3); }
+    | expression EQL expression { $$ = new BinaryExpression(Expression::EXP_EQL, $1, $3); }
+    | expression NEQ expression { $$ = new BinaryExpression(Expression::EXP_NEQ, $1, $3); }
+    | expression LSS expression { $$ = new BinaryExpression(Expression::EXP_LSS, $1, $3); }
+    | expression GTR expression { $$ = new BinaryExpression(Expression::EXP_GTR, $1, $3); }
+    | expression LEQ expression { $$ = new BinaryExpression(Expression::EXP_LEQ, $1, $3); }
+    | expression GEQ expression { $$ = new BinaryExpression(Expression::EXP_GEQ, $1, $3); }
+    | expression LSHIFT expression { $$ = new BinaryExpression(Expression::EXP_LSHIFT, $1, $3); }
+    | expression RSHIFT expression { $$ = new BinaryExpression(Expression::EXP_RSHIFT, $1, $3); }
+    | expression ADD expression { $$ = new BinaryExpression(Expression::EXP_ADD, $1, $3); }
+    | expression SUB expression { $$ = new BinaryExpression(Expression::EXP_SUB, $1, $3); }
+    | expression MUL expression { $$ = new BinaryExpression(Expression::EXP_MUL, $1, $3); }
+    | expression DIV expression { $$ = new BinaryExpression(Expression::EXP_DIV, $1, $3); }
+    | expression MOD expression { $$ = new BinaryExpression(Expression::EXP_MOD, $1, $3); }
     | unary_expression
     ;
 unary_expression :
     primary_expression
-    | NOT unary_expression
-    | REVERSE unary_expression
-    | SUB primary_expression
-    | ADD primary_expression
+    | NOT unary_expression { $$ = new UnaryExpression(Expression::EXP_NOT, $2); }
+    | REVERSE unary_expression { $$ = new UnaryExpression(Expression::EXP_REVERSE, $2); }
+    | SUB primary_expression { $$ = new UnaryExpression(Expression::EXP_SUB, $2); }
+    | ADD primary_expression { $$ = new UnaryExpression(Expression::EXP_ADD, $2); }
     ;
 primary_expression :
-    OPEN expression CLOSE
-    | INT_LITERAL
-    | DOUBLE_LITERAL
-    | CHAR_LITERAL
-    | STRING_LITERAL
-    | BINARY_LITERAL
-    | OCTA_LITERAL
-    | HEXA_LITERAL
+    OPEN expression CLOSE { $$ = $2; }
+    | INT_LITERAL { $$ = new ValueExpression(SignedIntValue::Create(pctx->getDataTypeTable()->Find(S64), $1)); }
+    | DOUBLE_LITERAL { $$ = new ValueExpression(FloatValue::Create(pctx->getDataTypeTable()->Find(F64), $1)); }
+    | CHAR_LITERAL { $$ = new ValueExpression(CharacterValue::Create(pctx->getDataTypeTable()->Find(C8), $1)); }
+    | STRING_LITERAL { $$ = new ValueExpression(StringValue::Create(pctx->getDataTypeTable()->Find(STR8), $1)); }
+    | BINARY_LITERAL { $$ = new ValueExpression(SignedIntValue::Create(pctx->getDataTypeTable()->Find(U64), $1)); }
+    | OCTA_LITERAL { $$ = new ValueExpression(UnsignedIntValue::Create(pctx->getDataTypeTable()->Find(U64), $1)); }
+    | HEXA_LITERAL { $$ = new ValueExpression(UnsignedIntValue::Create(pctx->getDataTypeTable()->Find(U64), $1)); }
     | variable_expression
     | function_expression
     ;
@@ -217,11 +246,23 @@ semi_start :
     line_opt SEMI line_opt
     ;
 type_specifier :
-    UINT8 | UINT16 | UINT32 | UINT64
-    | SINT8 | SINT16 | SINT32 | SINT64
-    | FLOAT32 | FLOAT64
-    | CHAR8 | CHAR16 | CHAR32
-    | STRING | STRING8 | STRING16 | STRING32
+    UINT8 { $$ = TypeSpecifier::U8; }
+    | UINT16 { $$ = TypeSpecifier::U16; }
+    | UINT32 { $$ = TypeSpecifier::U32; }
+    | UINT64 { $$ = TypeSpecifier::U64; }
+    | SINT8 { $$ = TypeSpecifier::S8; }
+    | SINT16 { $$ = TypeSpecifier::S16; }
+    | SINT32 { $$ = TypeSpecifier::S32; }
+    | SINT64 { $$ = TypeSpecifier::S64; }
+    | FLOAT32 { $$ = TypeSpecifier::F32; }
+    | FLOAT64 { $$ = TypeSpecifier::F64; }
+    | CHAR8 { $$ = TypeSpecifier::C8; }
+    | CHAR16 { $$ = TypeSpecifier::C16; }
+    | CHAR32 { $$ = TypeSpecifier::C32; }
+    | STRING { $$ = TypeSpecifier::STR8; }
+    | STRING8 { $$ = TypeSpecifier::STR8; }
+    | STRING16 { $$ = TypeSpecifier::STR16; }
+    | STRING32 { $$ = TypeSpecifier::STR32; }
     ;
 action_declaration : 
     block_statement

--- a/src/ast/statement/expression_statement.cpp
+++ b/src/ast/statement/expression_statement.cpp
@@ -11,8 +11,8 @@ namespace apus {
 
     }
 
-    ExpressionStatement::ExpressionStatement(Expression* expression) {
-        ExpressionStatement(ExprPtr(expression));
+    ExpressionStatement::ExpressionStatement(Expression* expression)
+      : ExpressionStatement(ExprPtr(expression)) {
     }
 
     ExpressionStatement::~ExpressionStatement() {


### PR DESCRIPTION
변경된 점
- STR은 STR8로 대응
- expression_statement.cpp에서 오류 수정 ( 세그먼테이션 오류의 원인 )
- expression 파트를 vm과 연동
- statement 파트를 vm과 연동
- string 스캔시, 공백있을시 공백 전까지의 string만 넘겨주는 문제 해결

v3
- STR을 생성하는 커밋 삭제
- String을 넘겨받는 코드 수정
