### PR TITLE
VM: Added Implementations of Variable

### DIFF
--- a/include/ast/expression.h
+++ b/include/ast/expression.h
@@ -7,6 +7,7 @@
 namespace apus {
 
     class Value;
+    class Variable;
     class Context;
 
     class Expression {
@@ -127,6 +128,7 @@ namespace apus {
         virtual ~VariableExpression();
 
         virtual std::shared_ptr<Value> Evaluate(Context& context);
+        std::shared_ptr<Variable> getVariable(Context& context);
 
     private:
         std::string name_;
@@ -134,15 +136,15 @@ namespace apus {
 
     class AssignExpression : public Expression {
     public:
-        AssignExpression(Type type, std::string name,
+        AssignExpression(Type type, std::shared_ptr<Expression> var_expr,
                          std::shared_ptr<Expression> expression);
-        AssignExpression(Type type, char* name, Expression* expression);
+        AssignExpression(Type type, Expression* var_expr, Expression* expression);
         virtual ~AssignExpression();
 
         virtual std::shared_ptr<Value> Evaluate(Context& context);
 
     private:
-        std::string name_;
+        std::shared_ptr<Expression> var_expr_;
         std::shared_ptr<Expression> expression_;
     };
 

--- a/include/ast/statement/var_def_statement.h
+++ b/include/ast/statement/var_def_statement.h
@@ -1,23 +1,38 @@
 #ifndef VAR_DEF_STATEMENT_H_
 #define VAR_DEF_STATEMENT_H_
 
+#include <memory>
+
+#include "common/common.h"
 #include "ast/statement/statement.h"
 
 namespace apus {
 
     class Context;
+    class Expression;
+    class DataType;
+
+    typedef std::shared_ptr<Expression> ExprPtr;
+    typedef std::shared_ptr<DataType> DataTypePtr;
 
     class VarDefStatement : public Statement {
     public:
 
-        VarDefStatement();
+        VarDefStatement(TypeSpecifier type, std::string name);
+        VarDefStatement(TypeSpecifier type, std::string name, Expression* initializer);
+        VarDefStatement(std::string type_name, std::string name);
+        VarDefStatement(std::string type_name, std::string name, Expression* initializer);
+
         virtual ~VarDefStatement();
 
         virtual Type getType() override { return STMT_VAR_DEF; }
         void Execute(Context& context) override;
 
     private:
-
+        TypeSpecifier type_;
+        std::string type_name_;
+        std::string name_;
+        ExprPtr initializer_;
     };
 
 }

--- a/include/vm/context.h
+++ b/include/vm/context.h
@@ -38,19 +38,13 @@ namespace apus {
         void InsertVariable(shared_ptr<Variable> variable);
         // TODO : InsertFunction();
 
-        inline bool GetBreak() { return break_; }
-        inline bool GetContinue() { return continue_; }
-        inline bool GetReturn() { return return_; }
-        inline bool GetExit() { return exit_; }
-        std::shared_ptr<Value> GetReturnType() { return return_type_; }
-        std::list<std::shared_ptr<Value>> GetArgList() { return arg_list_; }
+        inline bool GetBreak() { return *break_; }
+        inline bool GetContinue() { return *continue_; }
+        inline bool GetReturn() { return *return_; }
 
-        inline void SetBreak(bool _break) { break_ = _break;}
-        inline void SetContinue(bool _continue) { continue_ = _continue;}
-        inline void SetReturn(bool _return) { return_ = _return; }
-        inline void SetExit(bool _exit) { exit_ = _exit; }
-        void SetReturnType(std::shared_ptr<Value> _return_type) { return_type_ = _return_type; }
-        void SetArgList(std::list<std::shared_ptr<Value>> _arg_list) { arg_list_ = _arg_list; }
+        inline void SetBreak(bool _break) { *break_ = _break;}
+        inline void SetContinue(bool _continue) { *continue_ = _continue;}
+        inline void SetReturn(bool _return) { *return_ = _return; }
 
     private:
 
@@ -62,13 +56,9 @@ namespace apus {
         list<shared_ptr<DataType>> param_list_;
         shared_ptr<Value> return_value_;
 
-        bool break_;
-        bool continue_;
-        bool return_;
-        bool exit_;
-
-        std::list<std::shared_ptr<Value>> arg_list_;
-        std::shared_ptr<Value> return_type_;
+        shared_ptr<bool> break_;
+        shared_ptr<bool> continue_;
+        shared_ptr<bool> return_;
 
     };
 

--- a/include/vm/context.h
+++ b/include/vm/context.h
@@ -3,15 +3,40 @@
 
 #include <memory>
 #include <list>
+#include <string>
 #include "ast/value/value.h"
 
+using namespace std;
+
 namespace apus {
+
+    class Value;
+
+    class DataType;
+    class DataTypeTable;
+
+    class Variable;
+    class VariableTable;
 
     class Context {
     public:
 
-        Context();
+        Context(shared_ptr<DataTypeTable> data_type_table = nullptr);
+        Context(Context* context);
         virtual ~Context();
+
+        Context            BlockBegin();
+        shared_ptr<Value>  BlockEnd();
+
+        // Find
+        shared_ptr<DataType> FindDataType(TypeSpecifier type);
+        shared_ptr<DataType> FindDataType(string name);
+        shared_ptr<Variable> FindVariable(string name);
+        // TODO : FindFunction();
+
+        // Insert
+        void InsertVariable(shared_ptr<Variable> variable);
+        // TODO : InsertFunction();
 
         inline bool GetBreak() { return break_; }
         inline bool GetContinue() { return continue_; }
@@ -28,6 +53,14 @@ namespace apus {
         void SetArgList(std::list<std::shared_ptr<Value>> _arg_list) { arg_list_ = _arg_list; }
 
     private:
+
+        Context* parent_; // I'm not having it
+
+        shared_ptr<DataTypeTable> data_type_table_;
+        shared_ptr<VariableTable> variable_table_;
+
+        list<shared_ptr<DataType>> param_list_;
+        shared_ptr<Value> return_value_;
 
         bool break_;
         bool continue_;

--- a/src/apus.y
+++ b/src/apus.y
@@ -14,9 +14,11 @@ extern int yyerror(apus::ParserContext* pctx, char const *str);
 }
 
 %code requires {
+
     #include <memory>
     #include <list>
     #include <string>
+    #include <iostream>
 
     #include "common/common.h"
 
@@ -42,6 +44,9 @@ extern int yyerror(apus::ParserContext* pctx, char const *str);
     using namespace std;
     using namespace apus;
 
+    typedef shared_ptr<Statement> StmtPtr;
+    typedef list<StmtPtr> ListStmt;
+    typedef shared_ptr<ListStmt> ListStmtPtr; 
 }
 
 %union {
@@ -50,7 +55,8 @@ extern int yyerror(apus::ParserContext* pctx, char const *str);
     int char_val;
     char* str_val;
 
-    TypeSpecifier type_spec;
+    TypeSpecifier type_specifier;
+
     list<shared_ptr<Statement>>* list_stmt;
 
     Statement* stmt;
@@ -59,7 +65,6 @@ extern int yyerror(apus::ParserContext* pctx, char const *str);
     Expression::Type expr_type;
 
     Value* value;
-
 }
 
 %token<int_val> INT_LITERAL
@@ -95,17 +100,18 @@ extern int yyerror(apus::ParserContext* pctx, char const *str);
 
 %type<list_stmt> action_declaration_list action_declaration_opt
 
-%type<stmt> action_declaration for_statement if_statement else_if jump_statement
-%type<stmt> expression_statement var_def_statement block_statement
+%type<stmt> action_declaration for_statement if_statement else_if jump_statement expression_statement var_def_statement variable_definition block_statement
 
-%type<expr> expression expression_opt unary_expression primary_expression variable_expression
-%type<expr> init_expression const_expression
-
-%type<type_spec> type_specifier struct_union_type
+%type<expr> expression expression_opt unary_expression primary_expression variable_expression init_expression const_expression
+%type<expr_type> assign_operator
+%type<type_specifier> type_specifier struct_union_type
 
 %%
 program :
-    data_declaration_opt action_declaration_opt
+    data_declaration_opt action_declaration_opt {
+        pctx->SendDataTypeTableToVM();
+        pctx->getVM()->setStmtList(*$2);
+    }
     ;
 data_declaration_opt :
     /* empty */
@@ -199,20 +205,10 @@ dimension_array :
     ;
 expression_opt :
     /* empty */ { $$ = nullptr; }
-    | expression { $$ = $1; }
+    | expression
     ;
 expression :
-    variable_expression ASSIGN expression
-    | variable_expression ADDASSIGN expression
-    | variable_expression SUBASSIGN expression
-    | variable_expression MULASSIGN expression
-    | variable_expression DIVASSIGN expression
-    | variable_expression MODASSIGN expression
-    | variable_expression ORASSIGN expression
-    | variable_expression XORASSIGN expression
-    | variable_expression ANDASSIGN expression
-    | variable_expression LSASSIGN expression
-    | variable_expression RSASSIGN expression
+    variable_expression assign_operator expression { $$ = new AssignExpression($2, $1, $3);}
     | expression LOR expression { $$ = new BinaryExpression(Expression::EXP_LOR, $1, $3); }
     | expression LAND expression { $$ = new BinaryExpression(Expression::EXP_LAND, $1, $3); }
     | expression OR expression { $$ = new BinaryExpression(Expression::EXP_OR, $1, $3); }
@@ -253,7 +249,7 @@ primary_expression :
     | function_expression
     ;
 variable_expression :
-    ID
+    ID { $$ = new VariableExpression(std::string($1)); }
     | ID dimension_array
     | variable_expression DOT ID
     | variable_expression DOT ID dimension_array
@@ -306,6 +302,19 @@ type_specifier :
     | STRING16 { $$ = TypeSpecifier::STR16; }
     | STRING32 { $$ = TypeSpecifier::STR32; }
     ;
+assign_operator :
+    ASSIGN { $$ = Expression::EXP_ASSIGN; }
+    | ADDASSIGN { $$ = Expression::EXP_ADDASSIGN; }
+    | SUBASSIGN { $$ = Expression::EXP_SUBASSIGN; }
+    | MULASSIGN { $$ = Expression::EXP_MULASSIGN; }
+    | DIVASSIGN { $$ = Expression::EXP_DIVASSIGN; }
+    | MODASSIGN { $$ = Expression::EXP_MODASSIGN; }
+    | ORASSIGN { $$ = Expression::EXP_ORASSIGN; }
+    | ANDASSIGN { $$ = Expression::EXP_ANDASSIGN; }
+    | XORASSIGN {  $$ = Expression::EXP_XORASSIGN; }
+    | LSASSIGN { $$ = Expression::EXP_LSASSIGN; }
+    | RSASSIGN { $$ = Expression::EXP_RSASSIGN; }
+    ;
 action_declaration : 
     block_statement
     | if_statement
@@ -338,12 +347,12 @@ expression_statement :
     expression line_list { $$ = new ExpressionStatement($1); }
     ;
 var_def_statement :
-    VAR variable_definition line_list { $$ = new VarDefStatement(); }
+    VAR variable_definition line_list { $$ = $2;}
     ;
 variable_definition :
     type_specifier ID
     | struct_union_type ID ID
-    | type_specifier ID ASSIGN init_expression
+    | type_specifier ID ASSIGN init_expression { $$ = new VarDefStatement($1, $2, $4); }
     | struct_union_type ID ID ASSIGN init_expression
     | type_specifier dimension_array ID
     | type_specifier dimension_array ID ASSIGN init_expression

--- a/src/ast/expression.cpp
+++ b/src/ast/expression.cpp
@@ -1,5 +1,7 @@
 #include "ast/expression.h"
 #include "ast/value/value.h"
+
+#include "vm/variable_table.h"
 #include "vm/context.h"
 
 namespace apus {
@@ -123,25 +125,28 @@ namespace apus {
     }
 
     std::shared_ptr<Value> VariableExpression::Evaluate(Context &context) {
-        std::shared_ptr<Value> result = nullptr;
+        return context.FindVariable(name_)->getValue();
+    }
 
-        // find variable
 
-        return result;
+    std::shared_ptr<Variable> VariableExpression::getVariable(Context& context) {
+        return context.FindVariable(name_);
     }
 
     // AssignExpression::
 
     AssignExpression::AssignExpression(Type type,
-                                       std::string name,
+                                       std::shared_ptr<Expression> var_expr,
                                        std::shared_ptr<Expression> expression)
-        : Expression(type), name_(name), expression_(expression) {
+        : Expression(type), var_expr_(var_expr), expression_(expression) {
 
     }
 
-    AssignExpression::AssignExpression(Type type, char* name,
+    AssignExpression::AssignExpression(Type type,
+                                       Expression* var_expr,
                                        Expression* expression)
-        : AssignExpression(type, std::string(name), std::shared_ptr<Expression>(expression)) {
+        : AssignExpression(type, std::shared_ptr<Expression>(var_expr),
+                           std::shared_ptr<Expression>(expression)) {
     }
 
     AssignExpression::~AssignExpression() {
@@ -153,7 +158,7 @@ namespace apus {
         if (expression_ != nullptr) {
 
             // Find left value from the variable table
-            std::shared_ptr<Value> left = nullptr;
+            std::shared_ptr<Value> left = var_expr_->Evaluate(context);
             std::shared_ptr<Value> right = expression_->Evaluate(context);
 
             if (left != nullptr && right != nullptr) {
@@ -165,11 +170,13 @@ namespace apus {
                     std::shared_ptr<Value> result =
                             left->OperateBinary(this->getType(), right_promoted);
 
-                    // and, put 'result' value into the variable
+                    // TODO : and, put 'result' value into the variable
+                    std::shared_ptr<Variable> var = std::dynamic_pointer_cast<VariableExpression>(var_expr_)->getVariable(context);
+                    var->setValue(result);
 
+                    return result;
                 }
             }
-            return left;
         }
         return nullptr;
     }

--- a/src/ast/statement/block.cpp
+++ b/src/ast/statement/block.cpp
@@ -1,6 +1,10 @@
 #include "ast/statement/block.h"
 #include "vm/context.h"
 
+#include <iostream>
+
+using namespace std;
+
 namespace apus {
 
     Block::Block(std::list<StmtPtr> statements)
@@ -17,14 +21,18 @@ namespace apus {
 
     void Block::Execute(Context& context) {
 
-        for (StmtPtr stmt : statements_) {
-            stmt->Execute(context);
+        Context child = context.BlockBegin();
 
-            if (context.GetBreak() || context.GetContinue()
-                || context.GetReturn() || context.GetExit()) {
+        for (StmtPtr stmt : statements_) {
+
+            stmt->Execute(child);
+
+            if (child.GetBreak() || child.GetContinue() || child.GetReturn()) {
                 break;
             }
         }
+
+        child.BlockEnd();
     }
 
 }

--- a/src/ast/statement/jump_statement.cpp
+++ b/src/ast/statement/jump_statement.cpp
@@ -1,5 +1,11 @@
+#include <cstdlib>
+
 #include "ast/statement/jump_statement.h"
 #include "ast/statement/for_statement.h"
+
+#include "ast/value/signed_int_value.h"
+#include "ast/value/unsigned_int_value.h"
+
 #include "vm/context.h"
 
 namespace apus {
@@ -46,11 +52,22 @@ namespace apus {
 
     void ExitStatement::Execute(Context &context) {
 
+        int int_val = 0;
+
         if (expression_) {
-            expression_->Evaluate(context);
+            ValuePtr val = expression_->Evaluate(context);
+            TypeSpecifier val_type = val->getType();
+
+            if (S8 <= val_type && val_type <= S64) {
+                int_val = std::dynamic_pointer_cast<SignedIntValue>(val)->getIntValue();
+            }
+            else if (U8 <= val_type && val_type <= U64) {
+                int_val = std::dynamic_pointer_cast<UnsignedIntValue>(val)->getUIntValue();
+            }
+
         }
 
-        context.SetExit(true);
+        exit(int_val);
     }
 
 }

--- a/src/ast/statement/var_def_statement.cpp
+++ b/src/ast/statement/var_def_statement.cpp
@@ -60,6 +60,8 @@ namespace apus {
             var->setValue(nullptr);
         }
 
+        context.InsertVariable(var);
+
     }
 
 }

--- a/src/ast/statement/var_def_statement.cpp
+++ b/src/ast/statement/var_def_statement.cpp
@@ -1,10 +1,40 @@
 #include "ast/statement/var_def_statement.h"
+
+#include "ast/value/value.h"
+
+#include "vm/variable_table.h"
 #include "vm/context.h"
 
 namespace apus {
 
-    VarDefStatement::VarDefStatement() {
+    VarDefStatement::VarDefStatement(TypeSpecifier type, std::string name) {
+        type_ = type;
+        type_name_ = "";
+        name_ = name;
+        initializer_ = nullptr;
+    }
 
+    VarDefStatement::VarDefStatement(TypeSpecifier type, std::string name, Expression* initializer) {
+        type_ = type;
+        type_name_ = "";
+        name_ = name;
+        initializer_ = ExprPtr(initializer);
+    }
+
+    VarDefStatement::VarDefStatement(std::string type_name,
+                                     std::string name) {
+        type_ = NOT_DEFINED;
+        type_name_ = type_name;
+        name_ = name;
+        initializer_ = nullptr;
+    }
+
+    VarDefStatement::VarDefStatement(std::string type_name, std::string name,
+                                     Expression *initializer) {
+        type_ = NOT_DEFINED;
+        type_name_ = type_name;
+        name_ = name;
+        initializer_ = ExprPtr(initializer);
     }
 
     VarDefStatement::~VarDefStatement() {
@@ -12,6 +42,23 @@ namespace apus {
     }
 
     void VarDefStatement::Execute(Context& context) {
+
+        std::shared_ptr<Variable> var = nullptr;
+
+        if (type_ != NOT_DEFINED) {
+            var = std::make_shared<Variable>(name_, context.FindDataType(type_));
+        }
+        else {
+            var = std::make_shared<Variable>(name_, context.FindDataType(type_name_));
+        }
+
+        if (initializer_) {
+            var->setValue(initializer_->Evaluate(context));
+        }
+
+        else {
+            var->setValue(nullptr);
+        }
 
     }
 

--- a/src/vm/context.cpp
+++ b/src/vm/context.cpp
@@ -1,13 +1,78 @@
 #include "vm/context.h"
 
+#include "ast/value/value.h"
+#include "vm/data_type_table.h"
+#include "vm/variable_table.h"
+
 namespace apus {
 
-    Context::Context()
-        : break_(false), continue_(false) {
+    Context::Context(shared_ptr<DataTypeTable> data_type_table)
+        : parent_(nullptr), data_type_table_(data_type_table),
+          break_(false), continue_(false), return_(false), exit_(false) {
+
+        variable_table_ = make_shared<VariableTable>();
+        // TODO : create function table
+    }
+
+    Context::Context(Context* context)
+        : break_(false), continue_(false), return_(false), exit_(false) {
+        parent_ = context;
+        data_type_table_ = context->data_type_table_;
+
+        variable_table_ = make_shared<VariableTable>();
+        // TODO : create function table
     }
 
     Context::~Context() {
+    }
 
+    Context Context::BlockBegin() {
+
+        Context child(*this);
+        // TODO : Insert params into child.variable_table_
+
+        return child;
+    }
+
+    std::shared_ptr<Value> Context::BlockEnd() {
+
+        if (return_value_) {
+            parent_->return_value_ = return_value_;
+            return parent_->return_value_;
+        }
+
+        return nullptr;
+    }
+
+    shared_ptr<DataType> Context::FindDataType(TypeSpecifier name) {
+        return data_type_table_->Find(name);
+    }
+
+    shared_ptr<DataType> Context::FindDataType(string name) {
+        return data_type_table_->Find(name);
+    }
+
+    shared_ptr<Variable> Context::FindVariable(string name) {
+
+        shared_ptr<VariableTable> var_tab = variable_table_;
+        shared_ptr<Variable> var = nullptr;
+
+        Context* ctx_ptr = this;
+
+        while (ctx_ptr) {
+
+            if ( (var = ctx_ptr->variable_table_->Find(name)) ) {
+                return var;
+            }
+
+            ctx_ptr = ctx_ptr->parent_;
+        }
+
+        return nullptr;
+    }
+
+    void Context::InsertVariable(shared_ptr<Variable> variable) {
+        variable_table_->Insert(variable->getName(), variable);
     }
 
 }

--- a/src/vm/context.cpp
+++ b/src/vm/context.cpp
@@ -7,17 +7,24 @@
 namespace apus {
 
     Context::Context(shared_ptr<DataTypeTable> data_type_table)
-        : parent_(nullptr), data_type_table_(data_type_table),
-          break_(false), continue_(false), return_(false), exit_(false) {
+        : parent_(nullptr), data_type_table_(data_type_table) {
+
+        break_ = std::make_shared<bool>(false);
+        continue_ = std::make_shared<bool>(false);
+        return_ = std::make_shared<bool>(false);
 
         variable_table_ = make_shared<VariableTable>();
         // TODO : create function table
     }
 
-    Context::Context(Context* context)
-        : break_(false), continue_(false), return_(false), exit_(false) {
+    Context::Context(Context* context) {
         parent_ = context;
-        data_type_table_ = context->data_type_table_;
+
+        break_ = parent_->break_;
+        continue_ = parent_->continue_;
+        return_ = parent_->return_;
+
+        data_type_table_ = parent_->data_type_table_;
 
         variable_table_ = make_shared<VariableTable>();
         // TODO : create function table

--- a/src/vm/virtual_machine.cpp
+++ b/src/vm/virtual_machine.cpp
@@ -29,12 +29,10 @@ namespace apus {
 
     void VirtualMachine::Run() {
         static int count = 0;
-        Context context;
-        std::cout << "vm is Running..." << std::endl;
+        Context context(data_type_table_);
         
         for(std::shared_ptr<Statement> stmt : stmt_list_) {
             stmt->Execute(context);
-            std::cout << "Run count: " << ++count << std::endl;
         }
     }
 }

--- a/test/parser/array_test.cpp
+++ b/test/parser/array_test.cpp
@@ -43,7 +43,7 @@ var struct id2[2][2][2] ll = [[[{1, 2}, {3, 4}], [{5, 6}, {7, 8}]],\n\
 
 TEST (ParserTest, ArrayCorrectTest) {
     int result;
-    apus::ParserContext pctx;
+    apus::ParserContext pctx(std::make_shared<apus::VirtualMachine>());
 
     yy_scan_string(one_dimension_test_1);
     result = yyparse(&pctx);
@@ -64,7 +64,7 @@ TEST (ParserTest, ArrayCorrectTest) {
 
 TEST (ParserTest, ArrayCRTest) {
     int result;
-    apus::ParserContext pctx;
+    apus::ParserContext pctx(std::make_shared<apus::VirtualMachine>());
 
     yy_scan_string(three_dimension_test_3);
     result = yyparse(&pctx);

--- a/test/parser/data_decl_test.cpp
+++ b/test/parser/data_decl_test.cpp
@@ -35,7 +35,7 @@ union id6 { u32 aa }\n\
 
 TEST (ParserTest, DataDeclTest) {
     int result;
-    apus::ParserContext pctx;
+    apus::ParserContext pctx(std::make_shared<apus::VirtualMachine>());
 
     yy_scan_string(data_decl_test);
     result = yyparse(&pctx);

--- a/test/parser/statement_test.cpp
+++ b/test/parser/statement_test.cpp
@@ -85,6 +85,14 @@ if                      \n\
 else { }                \n\
 ";
 
+static char for_test[] =
+        "var s64 i = 0 \n\
+        for (i = 0;i < 3; i += 1) { \
+        var s64 a= 7 \n\
+        a+3 \n\
+        var s64 b = 3 \n\
+        b = a +2 + i\n if(b>=10){break\n}else{continue\n} } \n ";
+
 TEST (ParserTest, StmtCorrectTest) {
     int result;
     apus::ParserContext pctx(std::make_shared<apus::VirtualMachine>());
@@ -121,4 +129,14 @@ TEST (ParserTest, StmtLineTest) {
     yy_scan_string(if_stmt_test_3);
     result = yyparse(&pctx);
     EXPECT_EQ (result, 0);
+}
+
+TEST (ParserTest, StmtForTest) {
+    int result;
+    apus::ParserContext pctx(std::make_shared<apus::VirtualMachine>());
+
+    yy_scan_string(for_test);
+    result = yyparse(&pctx);
+    EXPECT_EQ (result, 0);
+    pctx.getVM()->Run();
 }

--- a/test/parser/statement_test.cpp
+++ b/test/parser/statement_test.cpp
@@ -87,7 +87,7 @@ else { }                \n\
 
 TEST (ParserTest, StmtCorrectTest) {
     int result;
-    apus::ParserContext pctx;
+    apus::ParserContext pctx(std::make_shared<apus::VirtualMachine>());
 
     yy_scan_string(var_def_test_1);
     result = yyparse(&pctx);
@@ -116,7 +116,7 @@ TEST (ParserTest, StmtCorrectTest) {
 
 TEST (ParserTest, StmtLineTest) {
     int result;
-    apus::ParserContext pctx;
+    apus::ParserContext pctx(std::make_shared<apus::VirtualMachine>());
 
     yy_scan_string(if_stmt_test_3);
     result = yyparse(&pctx);


### PR DESCRIPTION
 1 .  VarDefStatement의 생성자를 yacc의 rule에 맞게 수정했습니다.

 2 .  #86 에 언급한대로 context 를 구현했습니다. (테이블 추가, BlockBegin/End)

++ break, continue, return 과 같은 점프 플래그들은 DataTypeTable처럼 최상위 부모가 실체를 가지고 있고, 나머지 자식들이 이에 대한 포인터를 가지고 있어, 어느 context든 같은 플래그를 공유하게 했습니다. (break, continue같은 경우에는 한 단계만 더 전달하면 되지만, 앞으로 구현할 return의 경우, 함수 실행시 context까지 전달해야 하는데 이를 판단하기 어려울것이라고 생각해서 위처럼 구현했습니다.) break/continue는 ForStatement가 종료될때 플래그를 꺼 줍니다, return플래그는 FunctionExpression이 종료될때 플래그를 꺼주도록 구현할 예정입니다.

 3 .  변수와 관련 있는 expression 들의 내용을 채워넣었습니다. (VariableExpression, AssignExpression)

 4 . 위에서 수정, 생성한 클래스에 맞춰 Yacc action코드를 추가했습니다. 

++ VM인스턴스에 DataTypeTable을 전달하기 위해 ('program'에서의 action code) ParserContext에 VM의 인스턴스를 전달했습니다. 

 5 . 테스트 코드들을 추가했습니다.

( cout으로 출력하던 로그도 지웠습니다)
