### PR TITLE
parser: merge_data_decl-v1

### DIFF
--- a/src/apus.l
+++ b/src/apus.l
@@ -124,7 +124,7 @@
     int num_tmp;
     char* tmp = (char*)malloc(yyleng);
     sscanf(yytext, "0b%s", tmp);
-    num_tmp = strtol(tmp, NULL, 2);
+    num_tmp = strtoul(tmp, NULL, 2);
     yylval.int_val = num_tmp;
     free(tmp);
     return BINARY_LITERAL;
@@ -134,7 +134,7 @@
     int num_tmp;
     char* tmp = (char*)malloc(yyleng);
     sscanf(yytext, "0%s", tmp);
-    num_tmp = strtol(tmp, NULL, 8);
+    num_tmp = strtoul(tmp, NULL, 8);
     yylval.int_val = num_tmp;
     free(tmp);
     return OCTA_LITERAL;
@@ -144,7 +144,7 @@
     int num_tmp;
     char* tmp = (char*)malloc(yyleng);
     sscanf(yytext, "0x%s", tmp);
-    num_tmp = strtol(tmp, NULL, 16);
+    num_tmp = strtoul(tmp, NULL, 16);
     yylval.int_val = num_tmp;
     free(tmp);
     return HEXA_LITERAL;

--- a/src/apus.y
+++ b/src/apus.y
@@ -146,9 +146,8 @@ action_declaration_list :
     ;
 data_declaration :
     struct_union_type ID {
-        std::string str = $2;
         pctx->setCurrentDataType(std::make_shared<DataType>($1));
-        pctx->setCurrentName(str);
+        pctx->setCurrentName(string($2));
     } block_start member_definition_list R_BRACE line_list {
         pctx->ChangeCurrentDataType();
     }
@@ -163,13 +162,10 @@ member_definition_list :
     ;
 member_definition :
     type_specifier ID {
-        std::string str = $2;
-        pctx->AddToCurrentDataType(str, $1);
+        pctx->AddToCurrentDataType(string($2), $1);
     }
     | struct_union_type ID ID {
-        std::string str = $2;
-        std::string str2 = $3;
-        pctx->AddToCurrentDataType(str2, str);
+        pctx->AddToCurrentDataType(string($3), string($2));
     }
     | type_specifier ID ASSIGN const_expression
     | struct_union_type ID ID ASSIGN const_expression

--- a/src/apus.y
+++ b/src/apus.y
@@ -100,7 +100,8 @@ extern int yyerror(apus::ParserContext* pctx, char const *str);
 
 %type<list_stmt> action_declaration_list action_declaration_opt
 
-%type<stmt> action_declaration for_statement if_statement else_if jump_statement expression_statement var_def_statement variable_definition block_statement
+%type<stmt> action_declaration for_statement if_statement else_if jump_statement
+%type<stmt> expression_statement var_def_statement block_statement variable_definition
 
 %type<expr> expression expression_opt unary_expression primary_expression variable_expression init_expression const_expression
 %type<expr_type> assign_operator
@@ -343,13 +344,21 @@ expression_statement :
     expression line_list { $$ = new ExpressionStatement($1); }
     ;
 var_def_statement :
-    VAR variable_definition line_list { $$ = $2;}
+    VAR variable_definition line_list { $$ = $2; }
     ;
 variable_definition :
-    type_specifier ID
-    | struct_union_type ID ID
-    | type_specifier ID ASSIGN init_expression { $$ = new VarDefStatement($1, $2, $4); }
-    | struct_union_type ID ID ASSIGN init_expression
+    type_specifier ID {
+        $$ = new VarDefStatement($1, string($2));
+    }
+    | struct_union_type ID ID {
+        $$ = new VarDefStatement(string($2), string($3));
+    }
+    | type_specifier ID ASSIGN init_expression {
+        $$ = new VarDefStatement($1, string($2), $4);
+    }
+    | struct_union_type ID ID ASSIGN init_expression {
+        $$ = new VarDefStatement(string($2), string($3), $5);
+    }
     | type_specifier dimension_array ID
     | type_specifier dimension_array ID ASSIGN init_expression_list
     | struct_union_type ID dimension_array ID
@@ -360,7 +369,7 @@ init_expression_list :
     | init_expression comma_line_opt init_expression_list
     ;
 init_expression :
-    expression
+    expression { $$ = $1; }
     | struct_init
     | array_init
     ;

--- a/src/apus.y
+++ b/src/apus.y
@@ -108,9 +108,9 @@ extern int yyerror(apus::ParserContext* pctx, char const *str);
 
 %%
 program :
-    data_declaration_opt action_declaration_opt {
+    line_opt data_declaration_opt action_declaration_opt {
         pctx->SendDataTypeTableToVM();
-        pctx->getVM()->setStmtList(*$2);
+        pctx->getVM()->setStmtList(*$3);
     }
     ;
 data_declaration_opt :
@@ -355,9 +355,9 @@ variable_definition :
     | type_specifier ID ASSIGN init_expression { $$ = new VarDefStatement($1, $2, $4); }
     | struct_union_type ID ID ASSIGN init_expression
     | type_specifier dimension_array ID
-    | type_specifier dimension_array ID ASSIGN init_expression
+    | type_specifier dimension_array ID ASSIGN init_expression_list
     | struct_union_type ID dimension_array ID
-    | struct_union_type ID dimension_array ID ASSIGN init_expression
+    | struct_union_type ID dimension_array ID ASSIGN init_expression_list
     ;
 init_expression_list :
     init_expression


### PR DESCRIPTION
변경사항
- bin, hex, oct 와같은 radix를 unsigned int로 변형
- 일부분 init_expression을 init_expression_list로 수정
- 코드의 시작줄에 개행이 안되던 점 수정
- char*을 string으로 형변환 하는 방법을 깔끔하게 변경
- init_expression을 vm과 merge.

다음에는 STRUCT 부분을 연동하겠습니다.
