### PR TITLE
parser: merge_data_decl-v3

### DIFF
--- a/src/apus.l
+++ b/src/apus.l
@@ -121,30 +121,30 @@
 }
 
 0b[0-1]* {
-    int num_tmp;
+    uint64_t num_tmp;
     char* tmp = (char*)malloc(yyleng);
     sscanf(yytext, "0b%s", tmp);
-    num_tmp = strtol(tmp, NULL, 2);
+    num_tmp = strtoul(tmp, NULL, 2);
     yylval.int_val = num_tmp;
     free(tmp);
     return BINARY_LITERAL;
 }
 
 0[0-7]* {
-    int num_tmp;
+    uint64_t num_tmp;
     char* tmp = (char*)malloc(yyleng);
     sscanf(yytext, "0%s", tmp);
-    num_tmp = strtol(tmp, NULL, 8);
+    num_tmp = strtoul(tmp, NULL, 8);
     yylval.int_val = num_tmp;
     free(tmp);
     return OCTA_LITERAL;
 }
 
 0x[0-9a-fA-F]* {
-    int num_tmp;
+    uint64_t num_tmp;
     char* tmp = (char*)malloc(yyleng);
     sscanf(yytext, "0x%s", tmp);
-    num_tmp = strtol(tmp, NULL, 16);
+    num_tmp = strtoul(tmp, NULL, 16);
     yylval.int_val = num_tmp;
     free(tmp);
     return HEXA_LITERAL;

--- a/src/apus.y
+++ b/src/apus.y
@@ -51,6 +51,7 @@ extern int yyerror(apus::ParserContext* pctx, char const *str);
 
 %union {
     int64_t int_val;
+    uint64_t uint_val;
     double double_val;
     int char_val;
     char* str_val;
@@ -73,7 +74,7 @@ extern int yyerror(apus::ParserContext* pctx, char const *str);
 %token<char_val> CHAR_LITERAL
 %token<str_val> STRING_LITERAL
 %token<str_val> ID
-%token<int_val> BINARY_LITERAL OCTA_LITERAL HEXA_LITERAL
+%token<uint_val> BINARY_LITERAL OCTA_LITERAL HEXA_LITERAL
 
 %token<type_spec> UINT8 UINT16 UINT32 UINT64
 %token<type_spec> SINT8 SINT16 SINT32 SINT64
@@ -109,9 +110,9 @@ extern int yyerror(apus::ParserContext* pctx, char const *str);
 
 %%
 program :
-    data_declaration_opt action_declaration_opt {
+    line_opt data_declaration_opt action_declaration_opt {
         pctx->SendDataTypeTableToVM();
-        pctx->getVM()->setStmtList(*$2);
+        pctx->getVM()->setStmtList(*$3);
     }
     ;
 data_declaration_opt :
@@ -362,9 +363,9 @@ variable_definition :
     | type_specifier ID ASSIGN init_expression { $$ = new VarDefStatement($1, $2, $4); }
     | struct_union_type ID ID ASSIGN init_expression
     | type_specifier dimension_array ID
-    | type_specifier dimension_array ID ASSIGN init_expression
+    | type_specifier dimension_array ID ASSIGN init_expression_list
     | struct_union_type ID dimension_array ID
-    | struct_union_type ID dimension_array ID ASSIGN init_expression
+    | struct_union_type ID dimension_array ID ASSIGN init_expression_list
     ;
 init_expression_list :
     init_expression

--- a/src/apus.y
+++ b/src/apus.y
@@ -148,9 +148,8 @@ action_declaration_list :
     ;
 data_declaration :
     struct_union_type ID {
-        std::string str = $2;
         pctx->setCurrentDataType(std::make_shared<DataType>($1));
-        pctx->setCurrentName(str);
+        pctx->setCurrentName(string($2));
     } block_start member_definition_list R_BRACE line_list {
         pctx->ChangeCurrentDataType();
     }
@@ -165,13 +164,10 @@ member_definition_list :
     ;
 member_definition :
     type_specifier ID {
-        std::string str = $2;
-        pctx->AddToCurrentDataType(str, $1);
+        pctx->AddToCurrentDataType(string($2), $1);
     }
     | struct_union_type ID ID {
-        std::string str = $2;
-        std::string str2 = $3;
-        pctx->AddToCurrentDataType(str2, str);
+        pctx->AddToCurrentDataType(string($3), string($2));
     }
     | type_specifier ID ASSIGN const_expression
     | struct_union_type ID ID ASSIGN const_expression

--- a/src/apus.y
+++ b/src/apus.y
@@ -351,13 +351,21 @@ expression_statement :
     expression line_list { $$ = new ExpressionStatement($1); }
     ;
 var_def_statement :
-    VAR variable_definition line_list { $$ = $2;}
+    VAR variable_definition line_list { $$ = $2; }
     ;
 variable_definition :
-    type_specifier ID
-    | struct_union_type ID ID
-    | type_specifier ID ASSIGN init_expression { $$ = new VarDefStatement($1, $2, $4); }
-    | struct_union_type ID ID ASSIGN init_expression
+    type_specifier ID {
+        $$ = new VarDefStatement($1, string($2));
+    }
+    | struct_union_type ID ID {
+        $$ = new VarDefStatement(string($2), string($3));
+    }
+    | type_specifier ID ASSIGN init_expression {
+        $$ = new VarDefStatement($1, string($2), $4);
+    }
+    | struct_union_type ID ID ASSIGN init_expression {
+        $$ = new VarDefStatement(string($2), string($3), $5);
+    }
     | type_specifier dimension_array ID
     | type_specifier dimension_array ID ASSIGN init_expression_list
     | struct_union_type ID dimension_array ID
@@ -368,7 +376,7 @@ init_expression_list :
     | init_expression comma_line_opt init_expression_list
     ;
 init_expression :
-    expression
+    expression { $$ = $1; }
     | struct_init
     | array_init
     ;


### PR DESCRIPTION
변경사항
- bin, hex, oct 와같은 radix를 unsigned int로 변형
- 일부분 init_expression을 init_expression_list로 수정
- 코드의 시작줄에 개행이 안되던 점 수정
- char*을 string으로 형변환 하는 방법을 깔끔하게 변경
- init_expression을 vm과 merge.

v3
- int를 uint64_t로 수정.

배열은 다차원 배열을 지원하기 위해선 어쩔수 없이 list가 필요로 합니다.
그때 리스트가 필요없다했던 부분은 스트럭쳐에 실수로 list를 넣었을때로 기억하는데
혹시 제가 까먹은것일 수도 있기때문에, 알려주시면 감사합니다!
